### PR TITLE
feat(wip): verifiable upgrade path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,9 @@ name: CI
 
 on:
   push:
+    branches: [main]
+    tags: ["v*"]
   pull_request:
-  workflow_dispatch:
 
 env:
   FOUNDRY_PROFILE: ci
@@ -22,8 +23,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
 
       - name: Show Forge version
         run: |

--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,11 @@
+{
+  "lib/forge-std": {
+    "rev": "2b59872eee0b8088ddcade39fe8c041e17bb79c0"
+  },
+  "lib/openzeppelin-contracts": {
+    "rev": "ccb39d27656fc36eea331e3403c52b057885634d"
+  },
+  "lib/openzeppelin-contracts-upgradeable": {
+    "rev": "3d5fa5c24c411112bab47bec25cfa9ad0af0e6e8"
+  }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,4 +3,7 @@ src = "src"
 out = "out"
 libs = ["lib"]
 
+optimizer = true
+optimizer_runs = 1
+
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,2 +1,2 @@
 @openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
-@openzeppelin/contracts-upgradable/=lib/openzeppelin-contracts-upgradable/contracts/
+@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/

--- a/src/IProxyAuthorization.sol
+++ b/src/IProxyAuthorization.sol
@@ -4,7 +4,5 @@ pragma solidity ^0.8.20;
 interface IProxyAuthorization {
     function isAuthorizedToUpgrade(address caller) external view returns (bool);
 
-    function canUpgradeFrom(
-        address previousImplementation
-    ) external view returns (bool);
+    function canUpgradeFrom(address previousImplementation) external view returns (bool);
 }

--- a/src/IProxyAuthorization.sol
+++ b/src/IProxyAuthorization.sol
@@ -2,7 +2,5 @@
 pragma solidity ^0.8.20;
 
 interface IProxyAuthorization {
-    function isAuthorizedToUpgrade(address caller) external view returns (bool);
-
     function canUpgradeFrom(address previousImplementation) external view returns (bool);
 }

--- a/src/IProxyAuthorization.sol
+++ b/src/IProxyAuthorization.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IProxyAuthorization {
+    function isAuthorizedToUpgrade(address caller) external view returns (bool);
+
+    function canUpgradeFrom(
+        address previousImplementation
+    ) external view returns (bool);
+}

--- a/src/IUUPSProxy.sol
+++ b/src/IUUPSProxy.sol
@@ -8,7 +8,7 @@ interface IUUPSProxy {
 
     error ImplementationNotSet();
 
-    error InvalidUpgradeTargetForCurrentImplementation();
+    error InvalidUpgradeTarget(address currentImplementation, address newImplementation);
 
     error UpgradeNotAllowedInContext();
 

--- a/src/IUUPSProxy.sol
+++ b/src/IUUPSProxy.sol
@@ -12,7 +12,7 @@ interface IUUPSProxy {
 
     error UpgradeNotAllowedInContext();
 
-    function getVerifiableProxySalt() external view returns (bytes32);
+    function getVerifiableProxyData() external view returns (bytes32 salt, address implementation);
 
     function verifiableProxyFactory() external view returns (address);
 }

--- a/src/IUUPSProxy.sol
+++ b/src/IUUPSProxy.sol
@@ -2,6 +2,16 @@
 pragma solidity ^0.8.20;
 
 interface IUUPSProxy {
+    error ImplementationCannotBeZeroAddress();
+
+    error AlreadyInitialized();
+
+    error ImplementationNotSet();
+
+    error InvalidUpgradeTargetForCurrentImplementation();
+
+    error UpgradeNotAllowedInContext();
+
     function getVerifiableProxySalt() external view returns (bytes32);
 
     function verifiableProxyFactory() external view returns (address);

--- a/src/IVerifiableFactory.sol
+++ b/src/IVerifiableFactory.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IVerifiableFactory {
+    event ProxyDeployed(address indexed sender, address indexed proxyAddress, uint256 salt, address implementation);
+
+    function deployProxy(address implementation, uint256 salt, bytes memory data) external returns (address);
+
+    function verifyContract(address proxy, address expectedImplementation) external view returns (bool);
+}

--- a/src/UUPSProxy.sol
+++ b/src/UUPSProxy.sol
@@ -91,14 +91,21 @@ contract UUPSProxy is IUUPSProxy {
         return (_salt, _implementation());
     }
 
-    function upgradeToAndCall(address newImplementation, bytes memory /*data*/) public payable {
+    function upgradeToAndCall(
+        address newImplementation,
+        bytes memory /*data*/
+    )
+        public
+        payable
+    {
         if (newImplementation == address(0)) revert ImplementationCannotBeZeroAddress();
         if (_implementation() == address(0)) revert ImplementationNotSet();
 
         IProxyAuthorization newImpl = IProxyAuthorization(newImplementation);
 
-        if (!newImpl.canUpgradeFrom(_implementation()))
+        if (!newImpl.canUpgradeFrom(_implementation())) {
             revert InvalidUpgradeTarget(_implementation(), newImplementation);
+        }
 
         // forward the call to the implementation
         _delegate(_implementation(), false);

--- a/src/UUPSProxy.sol
+++ b/src/UUPSProxy.sol
@@ -108,7 +108,7 @@ contract UUPSProxy is Proxy, IUUPSProxy {
     }
 
     function _fallback() internal virtual override {
-        _delegate(_implementation());
+        _delegate(_implementation(), true);
     }
 
     receive() external payable {}

--- a/src/UUPSProxy.sol
+++ b/src/UUPSProxy.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.20;
 
 import {Proxy} from "@openzeppelin/contracts/proxy/Proxy.sol";
 import {ERC1967Utils, StorageSlot} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {SlotDerivation} from "@openzeppelin/contracts/utils/SlotDerivation.sol";
 
 import {IProxyAuthorization} from "./IProxyAuthorization.sol";
@@ -47,16 +48,15 @@ contract UUPSProxy is Proxy, IUUPSProxy {
         return _SALT_SLOT.erc7201Slot().getBytes32Slot().value;
     }
 
-    function upgradeToAndCall(address implementation, bytes memory data) public payable {
+    function upgradeToAndCall(address newImplementation, bytes memory /*data*/) public payable {
         require(_implementation() != address(0), "Implementation not set");
 
-        IProxyAuthorization currentImpl = IProxyAuthorization(address(this));
-        IProxyAuthorization newImpl = IProxyAuthorization(implementation);
+        IProxyAuthorization newImpl = IProxyAuthorization(newImplementation);
 
-        require(currentImpl.isAuthorizedToUpgrade(msg.sender), "Not authorized to upgrade");
         require(newImpl.canUpgradeFrom(_implementation()), "Cannot upgrade from this implementation");
 
-        ERC1967Utils.upgradeToAndCall(implementation, data);
+        // forward the call to the implementation
+        _delegate(_implementation(), false);
     }
 
     /**
@@ -74,7 +74,7 @@ contract UUPSProxy is Proxy, IUUPSProxy {
         _SALT_SLOT.erc7201Slot().getBytes32Slot().value = _salt;
     }
 
-    function _delegate(address implementation) internal virtual override {
+    function _delegate(address implementation, bool checkImplementation) internal {
         bytes32 implementationSlot = ERC1967Utils.IMPLEMENTATION_SLOT;
         assembly {
             // Copy msg.data. We take full control of memory in this inline assembly
@@ -89,7 +89,7 @@ contract UUPSProxy is Proxy, IUUPSProxy {
             // check if implementation has changed
             let implAfter := sload(implementationSlot)
 
-            if iszero(eq(implAfter, implementation)) {
+            if and(checkImplementation, iszero(eq(implAfter, implementation))) {
                 revert(0, 0)
             }
 
@@ -105,6 +105,10 @@ contract UUPSProxy is Proxy, IUUPSProxy {
                 return(0, returndatasize())
             }
         }
+    }
+
+    function _fallback() internal virtual override {
+        _delegate(_implementation());
     }
 
     receive() external payable {}

--- a/src/UUPSProxy.sol
+++ b/src/UUPSProxy.sol
@@ -38,8 +38,8 @@ contract UUPSProxy is Proxy, IUUPSProxy {
      * - If `data` is empty, `msg.value` must be zero.
      */
     function initialize(address implementation, bytes memory data) public payable {
-        require(implementation != address(0), "New implementation cannot be the zero address");
-        require(_implementation() == address(0), "Already initialized");
+        if (implementation == address(0)) revert ImplementationCannotBeZeroAddress();
+        if (_implementation() != address(0)) revert AlreadyInitialized();
 
         ERC1967Utils.upgradeToAndCall(implementation, data);
     }
@@ -49,11 +49,12 @@ contract UUPSProxy is Proxy, IUUPSProxy {
     }
 
     function upgradeToAndCall(address newImplementation, bytes memory /*data*/) public payable {
-        require(_implementation() != address(0), "Implementation not set");
+        if (newImplementation == address(0)) revert ImplementationCannotBeZeroAddress();
+        if (_implementation() == address(0)) revert ImplementationNotSet();
 
         IProxyAuthorization newImpl = IProxyAuthorization(newImplementation);
 
-        require(newImpl.canUpgradeFrom(_implementation()), "Cannot upgrade from this implementation");
+        if (!newImpl.canUpgradeFrom(_implementation())) revert InvalidUpgradeTargetForCurrentImplementation();
 
         // forward the call to the implementation
         _delegate(_implementation(), false);
@@ -76,6 +77,7 @@ contract UUPSProxy is Proxy, IUUPSProxy {
 
     function _delegate(address implementation, bool checkImplementation) internal {
         bytes32 implementationSlot = ERC1967Utils.IMPLEMENTATION_SLOT;
+        bytes4 errorSelector = IUUPSProxy.UpgradeNotAllowedInContext.selector;
         assembly {
             // Copy msg.data. We take full control of memory in this inline assembly
             // block because it will not return to Solidity code. We overwrite the
@@ -90,7 +92,9 @@ contract UUPSProxy is Proxy, IUUPSProxy {
             let implAfter := sload(implementationSlot)
 
             if and(checkImplementation, iszero(eq(implAfter, implementation))) {
-                revert(0, 0)
+                let ptr := mload(0x40)
+                mstore(ptr, errorSelector)
+                revert(ptr, 4)
             }
 
             // Copy the returned data.

--- a/src/UUPSProxy.sol
+++ b/src/UUPSProxy.sol
@@ -6,10 +6,7 @@
 pragma solidity ^0.8.20;
 
 import {Proxy} from "@openzeppelin/contracts/proxy/Proxy.sol";
-import {
-    ERC1967Utils,
-    StorageSlot
-} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
+import {ERC1967Utils, StorageSlot} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
 import {SlotDerivation} from "@openzeppelin/contracts/utils/SlotDerivation.sol";
 
 import {IProxyAuthorization} from "./IProxyAuthorization.sol";
@@ -39,14 +36,8 @@ contract UUPSProxy is Proxy, IUUPSProxy {
      *
      * - If `data` is empty, `msg.value` must be zero.
      */
-    function initialize(
-        address implementation,
-        bytes memory data
-    ) public payable {
-        require(
-            implementation != address(0),
-            "New implementation cannot be the zero address"
-        );
+    function initialize(address implementation, bytes memory data) public payable {
+        require(implementation != address(0), "New implementation cannot be the zero address");
         require(_implementation() == address(0), "Already initialized");
 
         ERC1967Utils.upgradeToAndCall(implementation, data);
@@ -56,23 +47,14 @@ contract UUPSProxy is Proxy, IUUPSProxy {
         return _SALT_SLOT.erc7201Slot().getBytes32Slot().value;
     }
 
-    function upgradeToAndCall(
-        address implementation,
-        bytes memory data
-    ) public payable {
+    function upgradeToAndCall(address implementation, bytes memory data) public payable {
         require(_implementation() != address(0), "Implementation not set");
 
         IProxyAuthorization currentImpl = IProxyAuthorization(address(this));
         IProxyAuthorization newImpl = IProxyAuthorization(implementation);
 
-        require(
-            currentImpl.isAuthorizedToUpgrade(msg.sender),
-            "Not authorized to upgrade"
-        );
-        require(
-            newImpl.canUpgradeFrom(_implementation()),
-            "Cannot upgrade from this implementation"
-        );
+        require(currentImpl.isAuthorizedToUpgrade(msg.sender), "Not authorized to upgrade");
+        require(newImpl.canUpgradeFrom(_implementation()), "Cannot upgrade from this implementation");
 
         ERC1967Utils.upgradeToAndCall(implementation, data);
     }
@@ -84,13 +66,7 @@ contract UUPSProxy is Proxy, IUUPSProxy {
      * the https://eth.wiki/json-rpc/API#eth_getstorageat[`eth_getStorageAt`] RPC call.
      * `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc`
      */
-    function _implementation()
-        internal
-        view
-        virtual
-        override
-        returns (address)
-    {
+    function _implementation() internal view virtual override returns (address) {
         return ERC1967Utils.getImplementation();
     }
 
@@ -108,14 +84,7 @@ contract UUPSProxy is Proxy, IUUPSProxy {
 
             // Call the implementation.
             // out and outsize are 0 because we don't know the size yet.
-            let result := delegatecall(
-                gas(),
-                implementation,
-                0,
-                calldatasize(),
-                0,
-                0
-            )
+            let result := delegatecall(gas(), implementation, 0, calldatasize(), 0, 0)
 
             // check if implementation has changed
             let implAfter := sload(implementationSlot)

--- a/src/UUPSProxy.sol
+++ b/src/UUPSProxy.sol
@@ -48,7 +48,7 @@ contract UUPSProxy is Proxy, IUUPSProxy {
         return (_SALT_SLOT.erc7201Slot().getBytes32Slot().value, _implementation());
     }
 
-    function upgradeToAndCall(address newImplementation, bytes memory /*data*/) public payable {
+    function upgradeToAndCall(address newImplementation, bytes memory /*data*/ ) public payable {
         if (newImplementation == address(0)) revert ImplementationCannotBeZeroAddress();
         if (_implementation() == address(0)) revert ImplementationNotSet();
 
@@ -102,12 +102,8 @@ contract UUPSProxy is Proxy, IUUPSProxy {
 
             switch result
             // delegatecall returns 0 on error.
-            case 0 {
-                revert(0, returndatasize())
-            }
-            default {
-                return(0, returndatasize())
-            }
+            case 0 { revert(0, returndatasize()) }
+            default { return(0, returndatasize()) }
         }
     }
 

--- a/src/UUPSProxy.sol
+++ b/src/UUPSProxy.sol
@@ -6,8 +6,13 @@
 pragma solidity ^0.8.20;
 
 import {Proxy} from "@openzeppelin/contracts/proxy/Proxy.sol";
-import {ERC1967Utils, StorageSlot} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
+import {
+    ERC1967Utils,
+    StorageSlot
+} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
 import {SlotDerivation} from "@openzeppelin/contracts/utils/SlotDerivation.sol";
+
+import {IProxyAuthorization} from "./IProxyAuthorization.sol";
 import {IUUPSProxy} from "./IUUPSProxy.sol";
 
 contract UUPSProxy is Proxy, IUUPSProxy {
@@ -34,8 +39,14 @@ contract UUPSProxy is Proxy, IUUPSProxy {
      *
      * - If `data` is empty, `msg.value` must be zero.
      */
-    function initialize(address implementation, bytes memory data) public payable {
-        require(implementation != address(0), "New implementation cannot be the zero address");
+    function initialize(
+        address implementation,
+        bytes memory data
+    ) public payable {
+        require(
+            implementation != address(0),
+            "New implementation cannot be the zero address"
+        );
         require(_implementation() == address(0), "Already initialized");
 
         ERC1967Utils.upgradeToAndCall(implementation, data);
@@ -45,6 +56,27 @@ contract UUPSProxy is Proxy, IUUPSProxy {
         return _SALT_SLOT.erc7201Slot().getBytes32Slot().value;
     }
 
+    function upgradeToAndCall(
+        address implementation,
+        bytes memory data
+    ) public payable {
+        require(_implementation() != address(0), "Implementation not set");
+
+        IProxyAuthorization currentImpl = IProxyAuthorization(address(this));
+        IProxyAuthorization newImpl = IProxyAuthorization(implementation);
+
+        require(
+            currentImpl.isAuthorizedToUpgrade(msg.sender),
+            "Not authorized to upgrade"
+        );
+        require(
+            newImpl.canUpgradeFrom(_implementation()),
+            "Cannot upgrade from this implementation"
+        );
+
+        ERC1967Utils.upgradeToAndCall(implementation, data);
+    }
+
     /**
      * @dev Returns the current implementation address.
      *
@@ -52,12 +84,58 @@ contract UUPSProxy is Proxy, IUUPSProxy {
      * the https://eth.wiki/json-rpc/API#eth_getstorageat[`eth_getStorageAt`] RPC call.
      * `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc`
      */
-    function _implementation() internal view virtual override returns (address) {
+    function _implementation()
+        internal
+        view
+        virtual
+        override
+        returns (address)
+    {
         return ERC1967Utils.getImplementation();
     }
 
     function _setSalt(bytes32 _salt) internal {
         _SALT_SLOT.erc7201Slot().getBytes32Slot().value = _salt;
+    }
+
+    function _delegate(address implementation) internal virtual override {
+        bytes32 implementationSlot = ERC1967Utils.IMPLEMENTATION_SLOT;
+        assembly {
+            // Copy msg.data. We take full control of memory in this inline assembly
+            // block because it will not return to Solidity code. We overwrite the
+            // Solidity scratch pad at memory position 0.
+            calldatacopy(0, 0, calldatasize())
+
+            // Call the implementation.
+            // out and outsize are 0 because we don't know the size yet.
+            let result := delegatecall(
+                gas(),
+                implementation,
+                0,
+                calldatasize(),
+                0,
+                0
+            )
+
+            // check if implementation has changed
+            let implAfter := sload(implementationSlot)
+
+            if iszero(eq(implAfter, implementation)) {
+                revert(0, 0)
+            }
+
+            // Copy the returned data.
+            returndatacopy(0, 0, returndatasize())
+
+            switch result
+            // delegatecall returns 0 on error.
+            case 0 {
+                revert(0, returndatasize())
+            }
+            default {
+                return(0, returndatasize())
+            }
+        }
     }
 
     receive() external payable {}

--- a/src/UUPSProxy.sol
+++ b/src/UUPSProxy.sol
@@ -37,11 +37,11 @@ contract UUPSProxy is IUUPSProxy {
     // immutable variable (in bytecode)
     address public immutable verifiableProxyFactory;
 
+    bytes32 internal immutable _salt;
+
     constructor(address _factory, bytes32 salt_) {
         verifiableProxyFactory = _factory;
-        assembly ("memory-safe") {
-            sstore(_SALT_SLOT, salt_)
-        }
+        _salt = salt_;
     }
 
     /**
@@ -91,7 +91,7 @@ contract UUPSProxy is IUUPSProxy {
     }
 
     function getVerifiableProxyData() public view returns (bytes32 salt, address implementation) {
-        return (_salt(), _implementation());
+        return (_salt, _implementation());
     }
 
     function upgradeToAndCall(address newImplementation, bytes memory /*data*/) public payable {
@@ -117,12 +117,6 @@ contract UUPSProxy is IUUPSProxy {
     function _implementation() internal view returns (address impl) {
         assembly {
             impl := sload(_IMPLEMENTATION_SLOT)
-        }
-    }
-
-    function _salt() internal view returns (bytes32 salt) {
-        assembly {
-            salt := sload(_SALT_SLOT)
         }
     }
 

--- a/src/UUPSProxy.sol
+++ b/src/UUPSProxy.sol
@@ -9,9 +9,6 @@ import {IProxyAuthorization} from "./IProxyAuthorization.sol";
 import {IUUPSProxy} from "./IUUPSProxy.sol";
 
 contract UUPSProxy is IUUPSProxy {
-    /// @dev `keccak256(bytes("eth.ens.proxy.verifiable.salt"))`.
-    bytes32 internal constant _SALT_SLOT = 0xb5b0a4d9ccf39d6e791e14c03248a14f4288ec2ddf7c269443c96ac5f0b17100; // "eth.ens.proxy.verifiable.salt"
-
     /// @dev `keccak256(bytes("eip1967.proxy.implementation")) - 1`.
     bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
 

--- a/src/UUPSProxy.sol
+++ b/src/UUPSProxy.sol
@@ -44,8 +44,8 @@ contract UUPSProxy is Proxy, IUUPSProxy {
         ERC1967Utils.upgradeToAndCall(implementation, data);
     }
 
-    function getVerifiableProxySalt() public view returns (bytes32) {
-        return _SALT_SLOT.erc7201Slot().getBytes32Slot().value;
+    function getVerifiableProxyData() public view returns (bytes32 salt, address implementation) {
+        return (_SALT_SLOT.erc7201Slot().getBytes32Slot().value, _implementation());
     }
 
     function upgradeToAndCall(address newImplementation, bytes memory /*data*/) public payable {

--- a/src/UUPSProxy.sol
+++ b/src/UUPSProxy.sol
@@ -5,26 +5,43 @@
 // @ref: @openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol
 pragma solidity ^0.8.20;
 
-import {Proxy} from "@openzeppelin/contracts/proxy/Proxy.sol";
-import {ERC1967Utils, StorageSlot} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {SlotDerivation} from "@openzeppelin/contracts/utils/SlotDerivation.sol";
-
 import {IProxyAuthorization} from "./IProxyAuthorization.sol";
 import {IUUPSProxy} from "./IUUPSProxy.sol";
 
-contract UUPSProxy is Proxy, IUUPSProxy {
-    using StorageSlot for bytes32;
-    using SlotDerivation for string;
+contract UUPSProxy is IUUPSProxy {
+    /// @dev `keccak256(bytes("eth.ens.proxy.verifiable.salt"))`.
+    bytes32 internal constant _SALT_SLOT = 0xb5b0a4d9ccf39d6e791e14c03248a14f4288ec2ddf7c269443c96ac5f0b17100; // "eth.ens.proxy.verifiable.salt"
 
-    string internal constant _SALT_SLOT = "eth.ens.proxy.verifiable.salt";
+    /// @dev `keccak256(bytes("eip1967.proxy.implementation")) - 1`.
+    bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    /// @dev `bytes4(keccak256(bytes("ImplementationCannotBeZeroAddress()")))`.
+    uint256 internal constant _IMPLEMENTATION_CANNOT_BE_ZERO_ADDRESS_ERROR_SELECTOR = 0x0760838f;
+
+    /// @dev `bytes4(keccak256(bytes("AlreadyInitialized()")))`.
+    uint256 internal constant _ALREADY_INITIALIZED_ERROR_SELECTOR = 0x0dc149f0;
+
+    /// @dev `bytes4(keccak256(bytes("UpgradeNotAllowedInContext()")))`.
+    uint256 internal constant _UPGRADE_NOT_ALLOWED_IN_CONTEXT_ERROR_SELECTOR = 0x784cf700;
+
+    /// @dev `bytes4(keccak256(bytes("ERC1967InvalidImplementation(address)")))`.
+    uint256 internal constant _ERC1967_INVALID_IMPLEMENTATION_ERROR_SELECTOR = 0x4c9c8ce3;
+
+    /// @dev `bytes4(keccak256(bytes("ERC1967NonPayable()")))`.
+    uint256 internal constant _ERC1967_NON_PAYABLE_ERROR_SELECTOR = 0xb398979f;
+
+    /// @dev `bytes4(keccak256(bytes("Upgraded(address)")))`.
+    uint256 internal constant _UPGRADED_EVENT_SELECTOR =
+        0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b;
 
     // immutable variable (in bytecode)
     address public immutable verifiableProxyFactory;
 
-    constructor(address _factory, bytes32 _salt) {
+    constructor(address _factory, bytes32 salt_) {
         verifiableProxyFactory = _factory;
-        _setSalt(_salt);
+        assembly ("memory-safe") {
+            sstore(_SALT_SLOT, salt_)
+        }
     }
 
     /**
@@ -38,23 +55,53 @@ contract UUPSProxy is Proxy, IUUPSProxy {
      * - If `data` is empty, `msg.value` must be zero.
      */
     function initialize(address implementation, bytes memory data) public payable {
-        if (implementation == address(0)) revert ImplementationCannotBeZeroAddress();
-        if (_implementation() != address(0)) revert AlreadyInitialized();
+        assembly {
+            if eq(implementation, 0) {
+                mstore(0, _IMPLEMENTATION_CANNOT_BE_ZERO_ADDRESS_ERROR_SELECTOR)
+                revert(0x1c, 0x04)
+            }
+            if iszero(eq(sload(_IMPLEMENTATION_SLOT), 0)) {
+                mstore(0, _ALREADY_INITIALIZED_ERROR_SELECTOR)
+                revert(0x1c, 0x04)
+            }
+            if iszero(extcodesize(implementation)) {
+                mstore(0, _ERC1967_INVALID_IMPLEMENTATION_ERROR_SELECTOR)
+                mstore(0x20, implementation)
+                revert(0x1c, 0x24)
+            }
+            sstore(_IMPLEMENTATION_SLOT, implementation)
+            log2(0, 0, _UPGRADED_EVENT_SELECTOR, implementation)
 
-        ERC1967Utils.upgradeToAndCall(implementation, data);
+            let dlength := mload(data)
+            switch dlength
+            case 0 {
+                if gt(0, callvalue()) {
+                    mstore(0, _ERC1967_NON_PAYABLE_ERROR_SELECTOR)
+                    revert(0x1c, 0x04)
+                }
+            }
+            default {
+                let result := delegatecall(gas(), implementation, add(data, 0x20), dlength, 0, 0)
+                if iszero(result) {
+                    returndatacopy(0, 0, returndatasize())
+                    revert(0, returndatasize())
+                }
+            }
+        }
     }
 
     function getVerifiableProxyData() public view returns (bytes32 salt, address implementation) {
-        return (_SALT_SLOT.erc7201Slot().getBytes32Slot().value, _implementation());
+        return (_salt(), _implementation());
     }
 
-    function upgradeToAndCall(address newImplementation, bytes memory /*data*/ ) public payable {
+    function upgradeToAndCall(address newImplementation, bytes memory /*data*/) public payable {
         if (newImplementation == address(0)) revert ImplementationCannotBeZeroAddress();
         if (_implementation() == address(0)) revert ImplementationNotSet();
 
         IProxyAuthorization newImpl = IProxyAuthorization(newImplementation);
 
-        if (!newImpl.canUpgradeFrom(_implementation())) revert InvalidUpgradeTargetForCurrentImplementation();
+        if (!newImpl.canUpgradeFrom(_implementation()))
+            revert InvalidUpgradeTarget(_implementation(), newImplementation);
 
         // forward the call to the implementation
         _delegate(_implementation(), false);
@@ -67,17 +114,19 @@ contract UUPSProxy is Proxy, IUUPSProxy {
      * the https://eth.wiki/json-rpc/API#eth_getstorageat[`eth_getStorageAt`] RPC call.
      * `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc`
      */
-    function _implementation() internal view virtual override returns (address) {
-        return ERC1967Utils.getImplementation();
+    function _implementation() internal view returns (address impl) {
+        assembly {
+            impl := sload(_IMPLEMENTATION_SLOT)
+        }
     }
 
-    function _setSalt(bytes32 _salt) internal {
-        _SALT_SLOT.erc7201Slot().getBytes32Slot().value = _salt;
+    function _salt() internal view returns (bytes32 salt) {
+        assembly {
+            salt := sload(_SALT_SLOT)
+        }
     }
 
     function _delegate(address implementation, bool checkImplementation) internal {
-        bytes32 implementationSlot = ERC1967Utils.IMPLEMENTATION_SLOT;
-        bytes4 errorSelector = IUUPSProxy.UpgradeNotAllowedInContext.selector;
         assembly {
             // Copy msg.data. We take full control of memory in this inline assembly
             // block because it will not return to Solidity code. We overwrite the
@@ -89,12 +138,11 @@ contract UUPSProxy is Proxy, IUUPSProxy {
             let result := delegatecall(gas(), implementation, 0, calldatasize(), 0, 0)
 
             // check if implementation has changed
-            let implAfter := sload(implementationSlot)
+            let implAfter := sload(_IMPLEMENTATION_SLOT)
 
             if and(checkImplementation, iszero(eq(implAfter, implementation))) {
-                let ptr := mload(0x40)
-                mstore(ptr, errorSelector)
-                revert(ptr, 4)
+                mstore(0, _UPGRADE_NOT_ALLOWED_IN_CONTEXT_ERROR_SELECTOR)
+                revert(0x1c, 0x04)
             }
 
             // Copy the returned data.
@@ -102,12 +150,16 @@ contract UUPSProxy is Proxy, IUUPSProxy {
 
             switch result
             // delegatecall returns 0 on error.
-            case 0 { revert(0, returndatasize()) }
-            default { return(0, returndatasize()) }
+            case 0 {
+                revert(0, returndatasize())
+            }
+            default {
+                return(0, returndatasize())
+            }
         }
     }
 
-    function _fallback() internal virtual override {
+    fallback() external payable {
         _delegate(_implementation(), true);
     }
 

--- a/src/VerifiableFactory.sol
+++ b/src/VerifiableFactory.sol
@@ -57,7 +57,6 @@ contract VerifiableFactory {
         try IUUPSProxy(proxy).getVerifiableProxySalt() returns (bytes32 salt) {
             return _verifyContract(proxy, salt);
         } catch {}
-
         return false;
     }
 

--- a/src/VerifiableFactory.sol
+++ b/src/VerifiableFactory.sol
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {console} from "forge-std/console.sol";
 import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 
 import {UUPSProxy} from "./UUPSProxy.sol";
 import {IUUPSProxy} from "./IUUPSProxy.sol";
+import {IVerifiableFactory} from "./IVerifiableFactory.sol";
 
-contract VerifiableFactory {
-    event ProxyDeployed(address indexed sender, address indexed proxyAddress, uint256 salt, address implementation);
-
+contract VerifiableFactory is IVerifiableFactory {
     /**
      * @dev Deploys a new `UUPSProxy` contract at a deterministic address.
      *
@@ -32,8 +30,6 @@ contract VerifiableFactory {
 
         UUPSProxy proxy = new UUPSProxy{salt: outerSalt}(address(this), outerSalt);
 
-        require(isContract(address(proxy)), "Proxy deployment failed");
-
         proxy.initialize(implementation, data);
 
         emit ProxyDeployed(msg.sender, address(proxy), salt, implementation);
@@ -50,11 +46,11 @@ contract VerifiableFactory {
      * @param proxy The address of the proxy contract being verified.
      * @return A boolean indicating whether the verification succeeded.
      */
-    function verifyContract(address proxy) public view returns (bool) {
-        if (!isContract(proxy)) {
-            return false;
-        }
-        try IUUPSProxy(proxy).getVerifiableProxySalt() returns (bytes32 salt) {
+    function verifyContract(address proxy, address expectedImplementation) public view returns (bool) {
+        if (!isContract(proxy)) return false;
+
+        try IUUPSProxy(proxy).getVerifiableProxyData() returns (bytes32 salt, address actualImplementation) {
+            if (actualImplementation != expectedImplementation) return false;
             return _verifyContract(proxy, salt);
         } catch {}
         return false;

--- a/src/mock/MockRegistry.sol
+++ b/src/mock/MockRegistry.sol
@@ -18,10 +18,6 @@ contract MockRegistry is UUPSUpgradeable, OwnableUpgradeable, IProxyAuthorizatio
     event AddressRegistered(address indexed account);
     event AddressUnregistered(address indexed account);
 
-    function isAuthorizedToUpgrade(address caller) external view virtual returns (bool) {
-        return owner() == caller;
-    }
-
     function canUpgradeFrom(address previousImplementation) external view virtual returns (bool) {
         return true;
     }

--- a/src/mock/MockRegistry.sol
+++ b/src/mock/MockRegistry.sol
@@ -1,12 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {
-    UUPSUpgradeable
-} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {
-    OwnableUpgradeable
-} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 import {IProxyAuthorization} from "../IProxyAuthorization.sol";
 
@@ -14,11 +10,7 @@ import {IProxyAuthorization} from "../IProxyAuthorization.sol";
  * @title MockRegistry
  * @dev Simulates a registry implementation for testing
  */
-contract MockRegistry is
-    UUPSUpgradeable,
-    OwnableUpgradeable,
-    IProxyAuthorization
-{
+contract MockRegistry is UUPSUpgradeable, OwnableUpgradeable, IProxyAuthorization {
     mapping(address => bool) public registeredAddresses;
     uint256 public constant version = 1;
 
@@ -26,21 +18,15 @@ contract MockRegistry is
     event AddressRegistered(address indexed account);
     event AddressUnregistered(address indexed account);
 
-    function isAuthorizedToUpgrade(
-        address caller
-    ) external view virtual returns (bool) {
+    function isAuthorizedToUpgrade(address caller) external view virtual returns (bool) {
         return owner() == caller;
     }
 
-    function canUpgradeFrom(
-        address previousImplementation
-    ) external view virtual returns (bool) {
+    function canUpgradeFrom(address previousImplementation) external view virtual returns (bool) {
         return true;
     }
 
-    function _authorizeUpgrade(
-        address newImplementation
-    ) internal override onlyOwner {}
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
     function initialize(address _owner) public initializer {
         __Ownable_init(_owner); // Initialize Ownable

--- a/src/mock/MockRegistry.sol
+++ b/src/mock/MockRegistry.sol
@@ -1,14 +1,24 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {
+    UUPSUpgradeable
+} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {
+    OwnableUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+import {IProxyAuthorization} from "../IProxyAuthorization.sol";
 
 /**
  * @title MockRegistry
  * @dev Simulates a registry implementation for testing
  */
-contract MockRegistry is UUPSUpgradeable, OwnableUpgradeable {
+contract MockRegistry is
+    UUPSUpgradeable,
+    OwnableUpgradeable,
+    IProxyAuthorization
+{
     mapping(address => bool) public registeredAddresses;
     uint256 public constant version = 1;
 
@@ -16,7 +26,21 @@ contract MockRegistry is UUPSUpgradeable, OwnableUpgradeable {
     event AddressRegistered(address indexed account);
     event AddressUnregistered(address indexed account);
 
-    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+    function isAuthorizedToUpgrade(
+        address caller
+    ) external view virtual returns (bool) {
+        return owner() == caller;
+    }
+
+    function canUpgradeFrom(
+        address previousImplementation
+    ) external view virtual returns (bool) {
+        return true;
+    }
+
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal override onlyOwner {}
 
     function initialize(address _owner) public initializer {
         __Ownable_init(_owner); // Initialize Ownable

--- a/src/mock/MockRegistryV2.sol
+++ b/src/mock/MockRegistryV2.sol
@@ -4,6 +4,18 @@ pragma solidity ^0.8.20;
 import {MockRegistry} from "./MockRegistry.sol";
 
 contract MockRegistryV2 is MockRegistry {
+    address immutable previousImpl;
+
+    constructor(address _previousImpl) {
+        previousImpl = _previousImpl;
+    }
+
+    function canUpgradeFrom(
+        address previousImplementation
+    ) external view override returns (bool) {
+        return previousImplementation == previousImpl;
+    }
+
     function getRegistryVersion() public pure override returns (uint256) {
         return 2;
     }

--- a/src/mock/MockRegistryV2.sol
+++ b/src/mock/MockRegistryV2.sol
@@ -10,9 +10,7 @@ contract MockRegistryV2 is MockRegistry {
         previousImpl = _previousImpl;
     }
 
-    function canUpgradeFrom(
-        address previousImplementation
-    ) external view override returns (bool) {
+    function canUpgradeFrom(address previousImplementation) external view override returns (bool) {
         return previousImplementation == previousImpl;
     }
 

--- a/src/mock/StorageCollusionImpl.sol
+++ b/src/mock/StorageCollusionImpl.sol
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {
+    UUPSUpgradeable
+} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {
+    OwnableUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 contract StorageConflictImplementation is UUPSUpgradeable, OwnableUpgradeable {
     // deliberate storage layout conflict
@@ -22,5 +26,11 @@ contract StorageConflictImplementation is UUPSUpgradeable, OwnableUpgradeable {
         assembly {
             sstore(0, 0xdeadbeef)
         }
+    }
+
+    function canUpgradeFrom(
+        address previousImplementation
+    ) external view returns (bool) {
+        return true;
     }
 }

--- a/src/mock/StorageCollusionImpl.sol
+++ b/src/mock/StorageCollusionImpl.sol
@@ -1,12 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {
-    UUPSUpgradeable
-} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {
-    OwnableUpgradeable
-} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 contract StorageConflictImplementation is UUPSUpgradeable, OwnableUpgradeable {
     // deliberate storage layout conflict
@@ -28,9 +24,7 @@ contract StorageConflictImplementation is UUPSUpgradeable, OwnableUpgradeable {
         }
     }
 
-    function canUpgradeFrom(
-        address previousImplementation
-    ) external view returns (bool) {
+    function canUpgradeFrom(address previousImplementation) external view returns (bool) {
         return true;
     }
 }

--- a/test/UUPSProxy.t.sol
+++ b/test/UUPSProxy.t.sol
@@ -3,14 +3,66 @@ pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";
 import "../src/UUPSProxy.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {SlotDerivation} from "@openzeppelin/contracts/utils/SlotDerivation.sol";
+import {
+    ERC1967Utils
+} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
+import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
 import {MockRegistry} from "../src/mock/MockRegistry.sol";
+
+contract MockProxyAuthorization is IProxyAuthorization, Ownable {
+    address allowedPreviousImpl;
+
+    constructor(
+        address initialOwner,
+        address allowedPreviousImpl_
+    ) Ownable(initialOwner) {
+        allowedPreviousImpl = allowedPreviousImpl_;
+    }
+
+    function isAuthorizedToUpgrade(
+        address caller
+    ) external view returns (bool) {
+        return owner() == caller;
+    }
+
+    function canUpgradeFrom(
+        address previousImplementation
+    ) external view returns (bool) {
+        return previousImplementation == allowedPreviousImpl;
+    }
+}
+
+contract MaliciousProxyAuthorization is IProxyAuthorization, Ownable {
+    constructor(address initialOwner) Ownable(initialOwner) {}
+
+    function isAuthorizedToUpgrade(
+        address caller
+    ) external view returns (bool) {
+        return true;
+    }
+
+    function canUpgradeFrom(
+        address previousImplementation
+    ) external view returns (bool) {
+        return true;
+    }
+
+    function changeImplementation(address newImplementation) external {
+        StorageSlot
+            .getAddressSlot(ERC1967Utils.IMPLEMENTATION_SLOT)
+            .value = newImplementation;
+    }
+}
 
 contract UUPSProxyTest is Test {
     using StorageSlot for bytes32;
     using SlotDerivation for string;
 
     UUPSProxy proxy;
+    MockProxyAuthorization mockProxyAuthorization;
+    MaliciousProxyAuthorization maliciousProxyAuthorization;
 
     address factory = address(0x1);
     address owner = address(0x2);
@@ -22,6 +74,11 @@ contract UUPSProxyTest is Test {
 
     function setUp() public {
         proxy = new UUPSProxy(factory, salt);
+        mockProxyAuthorization = new MockProxyAuthorization(
+            owner,
+            address(implementation)
+        );
+        maliciousProxyAuthorization = new MaliciousProxyAuthorization(owner);
     }
 
     function testInitialize() public {
@@ -47,6 +104,55 @@ contract UUPSProxyTest is Test {
         vm.store(address(proxy), saltSlot, computedSalt);
 
         // verify the updated salt
-        assertEq(proxy.getVerifiableProxySalt(), computedSalt, "Salt update failed");
+        assertEq(
+            proxy.getVerifiableProxySalt(),
+            computedSalt,
+            "Salt update failed"
+        );
+    }
+
+    function testUpgradeToAndCall() public {
+        // initialize the proxy
+        vm.prank(factory);
+        proxy.initialize(
+            implementation,
+            abi.encodeWithSelector(MockRegistry.initialize.selector, owner)
+        );
+        vm.stopPrank();
+
+        console.logAddress(MockRegistry(address(proxy)).owner());
+
+        // upgrade to proxy authorization
+        vm.prank(owner);
+        proxy.upgradeToAndCall(address(mockProxyAuthorization), emptyData);
+
+        // verify the upgrade
+        assertEq(
+            vm.load(address(proxy), ERC1967Utils.IMPLEMENTATION_SLOT),
+            bytes32(uint256(uint160(address(mockProxyAuthorization)))),
+            "Upgrade failed"
+        );
+    }
+
+    function testUpgradeToAndCall_Malicious() public {
+        vm.prank(factory);
+        proxy.initialize(address(mockProxyAuthorization), emptyData);
+
+        // upgrade to malicious proxy authorization
+        vm.prank(owner);
+        vm.expectRevert();
+        proxy.upgradeToAndCall(address(maliciousProxyAuthorization), emptyData);
+    }
+
+    function testChangeImplementation() public {
+        vm.prank(factory);
+        proxy.initialize(address(mockProxyAuthorization), emptyData);
+
+        // change the implementation
+        vm.prank(owner);
+        vm.expectRevert();
+        MaliciousProxyAuthorization(address(proxy)).changeImplementation(
+            address(implementation)
+        );
     }
 }

--- a/test/UUPSProxy.t.sol
+++ b/test/UUPSProxy.t.sol
@@ -5,31 +5,22 @@ import "forge-std/Test.sol";
 import "../src/UUPSProxy.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {SlotDerivation} from "@openzeppelin/contracts/utils/SlotDerivation.sol";
-import {
-    ERC1967Utils
-} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
+import {ERC1967Utils} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
 import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
 import {MockRegistry} from "../src/mock/MockRegistry.sol";
 
 contract MockProxyAuthorization is IProxyAuthorization, Ownable {
     address allowedPreviousImpl;
 
-    constructor(
-        address initialOwner,
-        address allowedPreviousImpl_
-    ) Ownable(initialOwner) {
+    constructor(address initialOwner, address allowedPreviousImpl_) Ownable(initialOwner) {
         allowedPreviousImpl = allowedPreviousImpl_;
     }
 
-    function isAuthorizedToUpgrade(
-        address caller
-    ) external view returns (bool) {
+    function isAuthorizedToUpgrade(address caller) external view returns (bool) {
         return owner() == caller;
     }
 
-    function canUpgradeFrom(
-        address previousImplementation
-    ) external view returns (bool) {
+    function canUpgradeFrom(address previousImplementation) external view returns (bool) {
         return previousImplementation == allowedPreviousImpl;
     }
 }
@@ -37,22 +28,16 @@ contract MockProxyAuthorization is IProxyAuthorization, Ownable {
 contract MaliciousProxyAuthorization is IProxyAuthorization, Ownable {
     constructor(address initialOwner) Ownable(initialOwner) {}
 
-    function isAuthorizedToUpgrade(
-        address caller
-    ) external view returns (bool) {
+    function isAuthorizedToUpgrade(address caller) external view returns (bool) {
         return true;
     }
 
-    function canUpgradeFrom(
-        address previousImplementation
-    ) external view returns (bool) {
+    function canUpgradeFrom(address previousImplementation) external view returns (bool) {
         return true;
     }
 
     function changeImplementation(address newImplementation) external {
-        StorageSlot
-            .getAddressSlot(ERC1967Utils.IMPLEMENTATION_SLOT)
-            .value = newImplementation;
+        StorageSlot.getAddressSlot(ERC1967Utils.IMPLEMENTATION_SLOT).value = newImplementation;
     }
 }
 
@@ -74,10 +59,7 @@ contract UUPSProxyTest is Test {
 
     function setUp() public {
         proxy = new UUPSProxy(factory, salt);
-        mockProxyAuthorization = new MockProxyAuthorization(
-            owner,
-            address(implementation)
-        );
+        mockProxyAuthorization = new MockProxyAuthorization(owner, address(implementation));
         maliciousProxyAuthorization = new MaliciousProxyAuthorization(owner);
     }
 
@@ -104,20 +86,13 @@ contract UUPSProxyTest is Test {
         vm.store(address(proxy), saltSlot, computedSalt);
 
         // verify the updated salt
-        assertEq(
-            proxy.getVerifiableProxySalt(),
-            computedSalt,
-            "Salt update failed"
-        );
+        assertEq(proxy.getVerifiableProxySalt(), computedSalt, "Salt update failed");
     }
 
     function testUpgradeToAndCall() public {
         // initialize the proxy
         vm.prank(factory);
-        proxy.initialize(
-            implementation,
-            abi.encodeWithSelector(MockRegistry.initialize.selector, owner)
-        );
+        proxy.initialize(implementation, abi.encodeWithSelector(MockRegistry.initialize.selector, owner));
         vm.stopPrank();
 
         console.logAddress(MockRegistry(address(proxy)).owner());
@@ -151,8 +126,6 @@ contract UUPSProxyTest is Test {
         // change the implementation
         vm.prank(owner);
         vm.expectRevert();
-        MaliciousProxyAuthorization(address(proxy)).changeImplementation(
-            address(implementation)
-        );
+        MaliciousProxyAuthorization(address(proxy)).changeImplementation(address(implementation));
     }
 }

--- a/test/UUPSProxy.t.sol
+++ b/test/UUPSProxy.t.sol
@@ -98,24 +98,6 @@ contract UUPSProxyTest is Test {
         proxy.initialize(implementation, emptyData);
     }
 
-    function test_SaltStorage() public {
-        // initialize the proxy
-        vm.prank(factory);
-        proxy.initialize(implementation, emptyData);
-
-        // use SlotDerivation to compute the salt slot
-        bytes32 saltSlot = _SALT_SLOT.erc7201Slot();
-
-        // directly manipulate the storage for the salt
-        uint256 newSalt = 54321;
-        bytes32 computedSalt = keccak256(abi.encode(owner, newSalt));
-        vm.store(address(proxy), saltSlot, computedSalt);
-
-        // verify the updated salt
-        (bytes32 actualSalt, ) = proxy.getVerifiableProxyData();
-        assertEq(actualSalt, computedSalt, "Salt update failed");
-    }
-
     function test_UpgradeToAndCall() public {
         // initialize the proxy
         vm.prank(factory);

--- a/test/UUPSProxy.t.sol
+++ b/test/UUPSProxy.t.sol
@@ -130,8 +130,7 @@ contract UUPSProxyTest is Test {
     function test_UpgradeToAndCall_UnauthorizedUpgrade() public {
         vm.prank(factory);
         proxy.initialize(
-            address(mockProxyAuthorization),
-            abi.encodeWithSelector(MockRegistry.initialize.selector, owner)
+            address(mockProxyAuthorization), abi.encodeWithSelector(MockRegistry.initialize.selector, owner)
         );
 
         vm.prank(maliciousUser);
@@ -152,8 +151,7 @@ contract UUPSProxyTest is Test {
             )
         );
         proxy.upgradeToAndCall(
-            address(mockProxyAuthorization),
-            abi.encodeWithSelector(MockRegistry.initialize.selector, owner)
+            address(mockProxyAuthorization), abi.encodeWithSelector(MockRegistry.initialize.selector, owner)
         );
     }
 

--- a/test/UUPSProxy.t.sol
+++ b/test/UUPSProxy.t.sol
@@ -112,7 +112,7 @@ contract UUPSProxyTest is Test {
         vm.store(address(proxy), saltSlot, computedSalt);
 
         // verify the updated salt
-        (bytes32 actualSalt, ) = proxy.getVerifiableProxyData();
+        (bytes32 actualSalt,) = proxy.getVerifiableProxyData();
         assertEq(actualSalt, computedSalt, "Salt update failed");
     }
 
@@ -148,8 +148,7 @@ contract UUPSProxyTest is Test {
     function test_UpgradeToAndCall_UnauthorizedUpgrade() public {
         vm.prank(factory);
         proxy.initialize(
-            address(mockProxyAuthorization),
-            abi.encodeWithSelector(MockRegistry.initialize.selector, owner)
+            address(mockProxyAuthorization), abi.encodeWithSelector(MockRegistry.initialize.selector, owner)
         );
 
         vm.prank(maliciousUser);
@@ -164,8 +163,7 @@ contract UUPSProxyTest is Test {
         vm.prank(owner);
         vm.expectRevert(abi.encodeWithSelector(IUUPSProxy.InvalidUpgradeTargetForCurrentImplementation.selector));
         proxy.upgradeToAndCall(
-            address(mockProxyAuthorization),
-            abi.encodeWithSelector(MockRegistry.initialize.selector, owner)
+            address(mockProxyAuthorization), abi.encodeWithSelector(MockRegistry.initialize.selector, owner)
         );
     }
 

--- a/test/UUPSProxy.t.sol
+++ b/test/UUPSProxy.t.sol
@@ -77,7 +77,9 @@ contract UUPSProxyTest is Test {
         proxy.initialize(implementation, abi.encodeWithSelector(MockRegistry.initialize.selector, owner));
 
         // check salt and owner values
-        assertEq(proxy.getVerifiableProxySalt(), salt, "Salt mismatch");
+        (bytes32 actualSalt, address actualImplementation) = proxy.getVerifiableProxyData();
+        assertEq(actualSalt, salt, "Salt mismatch");
+        assertEq(actualImplementation, implementation, "Implementation mismatch");
         assertEq(MockRegistry(address(proxy)).owner(), owner, "Owner mismatch");
     }
 
@@ -110,7 +112,8 @@ contract UUPSProxyTest is Test {
         vm.store(address(proxy), saltSlot, computedSalt);
 
         // verify the updated salt
-        assertEq(proxy.getVerifiableProxySalt(), computedSalt, "Salt update failed");
+        (bytes32 actualSalt, ) = proxy.getVerifiableProxyData();
+        assertEq(actualSalt, computedSalt, "Salt update failed");
     }
 
     function test_UpgradeToAndCall() public {
@@ -123,11 +126,8 @@ contract UUPSProxyTest is Test {
         proxy.upgradeToAndCall(address(mockProxyAuthorization), emptyData);
 
         // verify the upgrade
-        assertEq(
-            vm.load(address(proxy), ERC1967Utils.IMPLEMENTATION_SLOT),
-            bytes32(uint256(uint160(address(mockProxyAuthorization)))),
-            "Upgrade failed"
-        );
+        (, address actualImplementation) = proxy.getVerifiableProxyData();
+        assertEq(actualImplementation, address(mockProxyAuthorization), "Upgrade failed");
     }
 
     function test_UpgradeToAndCall_ZeroAddress() public {

--- a/test/UUPSProxy.t.sol
+++ b/test/UUPSProxy.t.sol
@@ -3,18 +3,24 @@ pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";
 import "../src/UUPSProxy.sol";
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {SlotDerivation} from "@openzeppelin/contracts/utils/SlotDerivation.sol";
 import {ERC1967Utils} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
 import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {MockRegistry} from "../src/mock/MockRegistry.sol";
+import {IUUPSProxy} from "../src/IUUPSProxy.sol";
 
-contract MockProxyAuthorization is IProxyAuthorization, Ownable, UUPSUpgradeable {
+contract MockProxyAuthorization is IProxyAuthorization, OwnableUpgradeable, UUPSUpgradeable {
     address allowedPreviousImpl;
 
-    constructor(address initialOwner, address allowedPreviousImpl_) Ownable(initialOwner) {
+    constructor(address allowedPreviousImpl_) {
         allowedPreviousImpl = allowedPreviousImpl_;
+    }
+
+    function initialize(address initialOwner) public initializer {
+        __Ownable_init(initialOwner);
+        __UUPSUpgradeable_init();
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
@@ -24,8 +30,12 @@ contract MockProxyAuthorization is IProxyAuthorization, Ownable, UUPSUpgradeable
     }
 }
 
-contract MaliciousProxyAuthorization is IProxyAuthorization, Ownable, UUPSUpgradeable {
-    constructor(address initialOwner) Ownable(initialOwner) {}
+contract MaliciousProxyAuthorization is IProxyAuthorization, UUPSUpgradeable {
+    constructor() {}
+
+    function initialize() public initializer {
+        __UUPSUpgradeable_init();
+    }
 
     function _authorizeUpgrade(address newImplementation) internal override {}
 
@@ -48,6 +58,7 @@ contract UUPSProxyTest is Test {
 
     address factory = address(0x1);
     address owner = address(0x2);
+    address maliciousUser = address(0x3);
     address implementation = address(new MockRegistry());
     bytes32 salt = bytes32(uint256(12345));
     bytes emptyData;
@@ -56,20 +67,36 @@ contract UUPSProxyTest is Test {
 
     function setUp() public {
         proxy = new UUPSProxy(factory, salt);
-        mockProxyAuthorization = new MockProxyAuthorization(owner, address(implementation));
-        maliciousProxyAuthorization = new MaliciousProxyAuthorization(owner);
+        mockProxyAuthorization = new MockProxyAuthorization(address(implementation));
+        maliciousProxyAuthorization = new MaliciousProxyAuthorization();
     }
 
-    function testInitialize() public {
+    function test_Initialize() public {
         // initialize the proxy
         vm.prank(factory);
-        proxy.initialize(implementation, emptyData);
+        proxy.initialize(implementation, abi.encodeWithSelector(MockRegistry.initialize.selector, owner));
 
         // check salt and owner values
         assertEq(proxy.getVerifiableProxySalt(), salt, "Salt mismatch");
+        assertEq(MockRegistry(address(proxy)).owner(), owner, "Owner mismatch");
     }
 
-    function testSaltStorage() public {
+    function test_Initialize_ZeroAddress() public {
+        vm.prank(factory);
+        vm.expectRevert(abi.encodeWithSelector(IUUPSProxy.ImplementationCannotBeZeroAddress.selector));
+        proxy.initialize(address(0), emptyData);
+    }
+
+    function test_Initialize_AlreadyInitialized() public {
+        vm.prank(factory);
+        proxy.initialize(implementation, abi.encodeWithSelector(MockRegistry.initialize.selector, owner));
+
+        vm.prank(factory);
+        vm.expectRevert(abi.encodeWithSelector(IUUPSProxy.AlreadyInitialized.selector));
+        proxy.initialize(implementation, emptyData);
+    }
+
+    function test_SaltStorage() public {
         // initialize the proxy
         vm.prank(factory);
         proxy.initialize(implementation, emptyData);
@@ -86,11 +113,10 @@ contract UUPSProxyTest is Test {
         assertEq(proxy.getVerifiableProxySalt(), computedSalt, "Salt update failed");
     }
 
-    function testUpgradeToAndCall() public {
+    function test_UpgradeToAndCall() public {
         // initialize the proxy
         vm.prank(factory);
         proxy.initialize(implementation, abi.encodeWithSelector(MockRegistry.initialize.selector, owner));
-        vm.stopPrank();
 
         // upgrade to proxy authorization
         vm.prank(owner);
@@ -104,23 +130,52 @@ contract UUPSProxyTest is Test {
         );
     }
 
-    function testUpgradeToAndCall_Malicious() public {
+    function test_UpgradeToAndCall_ZeroAddress() public {
         vm.prank(factory);
-        proxy.initialize(address(mockProxyAuthorization), emptyData);
+        proxy.initialize(implementation, abi.encodeWithSelector(MockRegistry.initialize.selector, owner));
 
-        // upgrade to malicious proxy authorization
         vm.prank(owner);
-        vm.expectRevert();
+        vm.expectRevert(abi.encodeWithSelector(IUUPSProxy.ImplementationCannotBeZeroAddress.selector));
+        proxy.upgradeToAndCall(address(0), emptyData);
+    }
+
+    function test_UpgradeToAndCall_ImplementationNotSet() public {
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(IUUPSProxy.ImplementationNotSet.selector));
+        proxy.upgradeToAndCall(address(mockProxyAuthorization), emptyData);
+    }
+
+    function test_UpgradeToAndCall_UnauthorizedUpgrade() public {
+        vm.prank(factory);
+        proxy.initialize(
+            address(mockProxyAuthorization),
+            abi.encodeWithSelector(MockRegistry.initialize.selector, owner)
+        );
+
+        vm.prank(maliciousUser);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, maliciousUser));
         proxy.upgradeToAndCall(address(maliciousProxyAuthorization), emptyData);
     }
 
-    function testChangeImplementation() public {
+    function test_UpgradeToAndCall_InvalidUpgradeTargetForCurrentImplementation() public {
         vm.prank(factory);
-        proxy.initialize(address(mockProxyAuthorization), emptyData);
+        proxy.initialize(address(maliciousProxyAuthorization), emptyData);
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(IUUPSProxy.InvalidUpgradeTargetForCurrentImplementation.selector));
+        proxy.upgradeToAndCall(
+            address(mockProxyAuthorization),
+            abi.encodeWithSelector(MockRegistry.initialize.selector, owner)
+        );
+    }
+
+    function test_UpgradeNotAllowedInContext() public {
+        vm.prank(factory);
+        proxy.initialize(address(maliciousProxyAuthorization), emptyData);
 
         // change the implementation
         vm.prank(owner);
-        vm.expectRevert();
+        vm.expectRevert(abi.encodeWithSelector(IUUPSProxy.UpgradeNotAllowedInContext.selector));
         MaliciousProxyAuthorization(address(proxy)).changeImplementation(address(implementation));
     }
 }

--- a/test/UUPSProxy.t.sol
+++ b/test/UUPSProxy.t.sol
@@ -7,30 +7,27 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {SlotDerivation} from "@openzeppelin/contracts/utils/SlotDerivation.sol";
 import {ERC1967Utils} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
 import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {MockRegistry} from "../src/mock/MockRegistry.sol";
 
-contract MockProxyAuthorization is IProxyAuthorization, Ownable {
+contract MockProxyAuthorization is IProxyAuthorization, Ownable, UUPSUpgradeable {
     address allowedPreviousImpl;
 
     constructor(address initialOwner, address allowedPreviousImpl_) Ownable(initialOwner) {
         allowedPreviousImpl = allowedPreviousImpl_;
     }
 
-    function isAuthorizedToUpgrade(address caller) external view returns (bool) {
-        return owner() == caller;
-    }
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
     function canUpgradeFrom(address previousImplementation) external view returns (bool) {
         return previousImplementation == allowedPreviousImpl;
     }
 }
 
-contract MaliciousProxyAuthorization is IProxyAuthorization, Ownable {
+contract MaliciousProxyAuthorization is IProxyAuthorization, Ownable, UUPSUpgradeable {
     constructor(address initialOwner) Ownable(initialOwner) {}
 
-    function isAuthorizedToUpgrade(address caller) external view returns (bool) {
-        return true;
-    }
+    function _authorizeUpgrade(address newImplementation) internal override {}
 
     function canUpgradeFrom(address previousImplementation) external view returns (bool) {
         return true;
@@ -94,8 +91,6 @@ contract UUPSProxyTest is Test {
         vm.prank(factory);
         proxy.initialize(implementation, abi.encodeWithSelector(MockRegistry.initialize.selector, owner));
         vm.stopPrank();
-
-        console.logAddress(MockRegistry(address(proxy)).owner());
 
         // upgrade to proxy authorization
         vm.prank(owner);

--- a/test/UUPSProxy.t.sol
+++ b/test/UUPSProxy.t.sol
@@ -112,7 +112,7 @@ contract UUPSProxyTest is Test {
         vm.store(address(proxy), saltSlot, computedSalt);
 
         // verify the updated salt
-        (bytes32 actualSalt,) = proxy.getVerifiableProxyData();
+        (bytes32 actualSalt, ) = proxy.getVerifiableProxyData();
         assertEq(actualSalt, computedSalt, "Salt update failed");
     }
 
@@ -148,7 +148,8 @@ contract UUPSProxyTest is Test {
     function test_UpgradeToAndCall_UnauthorizedUpgrade() public {
         vm.prank(factory);
         proxy.initialize(
-            address(mockProxyAuthorization), abi.encodeWithSelector(MockRegistry.initialize.selector, owner)
+            address(mockProxyAuthorization),
+            abi.encodeWithSelector(MockRegistry.initialize.selector, owner)
         );
 
         vm.prank(maliciousUser);
@@ -161,9 +162,16 @@ contract UUPSProxyTest is Test {
         proxy.initialize(address(maliciousProxyAuthorization), emptyData);
 
         vm.prank(owner);
-        vm.expectRevert(abi.encodeWithSelector(IUUPSProxy.InvalidUpgradeTargetForCurrentImplementation.selector));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IUUPSProxy.InvalidUpgradeTarget.selector,
+                address(maliciousProxyAuthorization),
+                address(mockProxyAuthorization)
+            )
+        );
         proxy.upgradeToAndCall(
-            address(mockProxyAuthorization), abi.encodeWithSelector(MockRegistry.initialize.selector, owner)
+            address(mockProxyAuthorization),
+            abi.encodeWithSelector(MockRegistry.initialize.selector, owner)
         );
     }
 

--- a/test/VerifiableFactory.t.sol
+++ b/test/VerifiableFactory.t.sol
@@ -3,7 +3,10 @@ pragma solidity ^0.8.20;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
-import {OwnableUpgradeable, Initializable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {
+    OwnableUpgradeable,
+    Initializable
+} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 import {VerifiableFactory} from "../src/VerifiableFactory.sol";
 import {UUPSProxy} from "../src/UUPSProxy.sol";
@@ -11,13 +14,16 @@ import {IUUPSProxy} from "../src/IUUPSProxy.sol";
 import {MockRegistry} from "../src/mock/MockRegistry.sol";
 import {MockRegistryV2} from "../src/mock/MockRegistryV2.sol";
 import {NonUUPSImpl} from "../src/mock/NonUUPSImpl.sol";
-import {StorageConflictImplementation} from "../src/mock/StorageCollusionImpl.sol";
+import {
+    StorageConflictImplementation
+} from "../src/mock/StorageCollusionImpl.sol";
 
 contract VerifiableFactoryTest is Test {
     // contract instances
     VerifiableFactory public factory;
     MockRegistry public implementation;
     MockRegistryV2 public implementationV2;
+    MockRegistryV2 public nonTrustedImpl;
 
     // test addresses
     address public owner;
@@ -26,7 +32,12 @@ contract VerifiableFactoryTest is Test {
     bytes emptyData;
 
     // ### Events
-    event ProxyDeployed(address indexed sender, address indexed proxyAddress, uint256 salt, address implementation);
+    event ProxyDeployed(
+        address indexed sender,
+        address indexed proxyAddress,
+        uint256 salt,
+        address implementation
+    );
 
     function setUp() public {
         owner = makeAddr("owner");
@@ -36,7 +47,8 @@ contract VerifiableFactoryTest is Test {
         // deploy contracts
         factory = new VerifiableFactory();
         implementation = new MockRegistry();
-        implementationV2 = new MockRegistryV2();
+        implementationV2 = new MockRegistryV2(address(implementation));
+        nonTrustedImpl = new MockRegistryV2(address(implementation));
 
         vm.label(address(factory), "Factory");
         vm.label(address(implementation), "Implementation");
@@ -45,7 +57,10 @@ contract VerifiableFactoryTest is Test {
 
     function test_FactoryInitialState() public view {
         assertTrue(address(factory) != address(0), "Factory deployment failed");
-        assertTrue(address(implementation) != address(0), "Implementation deployment failed");
+        assertTrue(
+            address(implementation) != address(0),
+            "Implementation deployment failed"
+        );
     }
 
     function test_DeployProxy() public {
@@ -53,22 +68,42 @@ contract VerifiableFactoryTest is Test {
 
         // test event emit
         vm.expectEmit(true, true, true, true);
-        emit ProxyDeployed(owner, computeExpectedAddress(salt), salt, address(implementation));
+        emit ProxyDeployed(
+            owner,
+            computeExpectedAddress(salt),
+            salt,
+            address(implementation)
+        );
 
         vm.startPrank(owner);
-        address proxyAddress = factory.deployProxy(address(implementation), salt, emptyData);
+        address proxyAddress = factory.deployProxy(
+            address(implementation),
+            salt,
+            emptyData
+        );
 
         vm.stopPrank();
 
         // verify proxy deployment
-        assertTrue(proxyAddress != address(0), "Proxy address should not be zero");
+        assertTrue(
+            proxyAddress != address(0),
+            "Proxy address should not be zero"
+        );
         assertTrue(isContract(proxyAddress), "Proxy should be a contract");
 
         // verify proxy state
         UUPSProxy proxy = UUPSProxy(payable(proxyAddress));
         bytes32 computedSalt = keccak256(abi.encode(owner, salt));
-        assertEq(proxy.getVerifiableProxySalt(), computedSalt, "Proxy salt mismatch");
-        assertEq(proxy.verifiableProxyFactory(), address(factory), "Proxy factory mismatch");
+        assertEq(
+            proxy.getVerifiableProxySalt(),
+            computedSalt,
+            "Proxy salt mismatch"
+        );
+        assertEq(
+            proxy.verifiableProxyFactory(),
+            address(factory),
+            "Proxy factory mismatch"
+        );
     }
 
     function test_DeployProxyWithSameSalt() public {
@@ -88,16 +123,23 @@ contract VerifiableFactoryTest is Test {
     function test_UpgradeImplementation() public {
         uint256 salt = 1;
 
-        bytes memory initData = abi.encodeWithSelector(MockRegistry.initialize.selector, owner);
+        bytes memory initData = abi.encodeWithSelector(
+            MockRegistry.initialize.selector,
+            owner
+        );
         // deploy proxy as owner
         vm.prank(owner);
-        address proxyAddress = factory.deployProxy(address(implementation), salt, initData);
+        address proxyAddress = factory.deployProxy(
+            address(implementation),
+            salt,
+            initData
+        );
 
         MockRegistry proxyV1 = MockRegistry(proxyAddress);
 
         // try to upgrade as non-owner (should fail)
         vm.prank(maliciousUser);
-        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, maliciousUser));
+        vm.expectRevert("Not authorized to upgrade");
         proxyV1.upgradeToAndCall(
             address(implementationV2),
             "" // add upgrade data if we need
@@ -112,18 +154,31 @@ contract VerifiableFactoryTest is Test {
 
         // verify new implementation
         MockRegistryV2 upgradedProxy = MockRegistryV2(proxyAddress);
-        assertEq(upgradedProxy.getRegistryVersion(), 2, "Implementation upgrade failed");
-        vm.expectRevert(abi.encodeWithSelector(Initializable.InvalidInitialization.selector));
+        assertEq(
+            upgradedProxy.getRegistryVersion(),
+            2,
+            "Implementation upgrade failed"
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(Initializable.InvalidInitialization.selector)
+        );
         upgradedProxy.initialize(owner);
     }
 
     function test_UpgradeToNonUUPS() public {
         uint256 salt = 1;
-        bytes memory initData = abi.encodeWithSelector(MockRegistry.initialize.selector, owner);
+        bytes memory initData = abi.encodeWithSelector(
+            MockRegistry.initialize.selector,
+            owner
+        );
 
         // Deploy proxy
         vm.prank(owner);
-        address proxyAddress = factory.deployProxy(address(implementation), salt, initData);
+        address proxyAddress = factory.deployProxy(
+            address(implementation),
+            salt,
+            initData
+        );
 
         // attempt upgrade to non-UUPS contract
         NonUUPSImpl badImpl = new NonUUPSImpl();
@@ -134,12 +189,37 @@ contract VerifiableFactoryTest is Test {
         proxy.upgradeToAndCall(address(badImpl), "");
     }
 
+    function test_UpgradeToNonCompatibleImplementation() public {
+        uint256 salt = 1;
+        bytes memory initData = abi.encodeWithSelector(
+            MockRegistry.initialize.selector,
+            owner
+        );
+
+        // deploy proxy
+        vm.prank(owner);
+        address proxyAddress = factory.deployProxy(
+            address(implementationV2),
+            salt,
+            initData
+        );
+        MockRegistryV2 proxy = MockRegistryV2(proxyAddress);
+
+        vm.prank(owner);
+        vm.expectRevert();
+        proxy.upgradeToAndCall(address(nonTrustedImpl), "");
+    }
+
     function test_VerifyContract() public {
         uint256 salt = 1;
 
         // deploy proxy
         vm.prank(owner);
-        address proxyAddress = factory.deployProxy(address(implementation), salt, emptyData);
+        address proxyAddress = factory.deployProxy(
+            address(implementation),
+            salt,
+            emptyData
+        );
 
         vm.prank(owner);
         // verify the contract
@@ -158,25 +238,40 @@ contract VerifiableFactoryTest is Test {
 
         // deploy proxy
         vm.prank(owner);
-        address proxyAddress = factory.deployProxy(address(implementation), salt, emptyData);
+        address proxyAddress = factory.deployProxy(
+            address(implementation),
+            salt,
+            emptyData
+        );
 
         // test proxy state
         UUPSProxy proxy = UUPSProxy(payable(proxyAddress));
 
         bytes32 computedSalt = keccak256(abi.encode(owner, salt));
         assertEq(proxy.getVerifiableProxySalt(), computedSalt, "Wrong salt");
-        assertEq(proxy.verifiableProxyFactory(), address(factory), "Wrong factory");
+        assertEq(
+            proxy.verifiableProxyFactory(),
+            address(factory),
+            "Wrong factory"
+        );
     }
 
     function test_StoragePersistenceAfterUpgrade() public {
         uint256 salt = 1;
         address testAccount = makeAddr("testAccount");
 
-        bytes memory initData = abi.encodeWithSelector(MockRegistry.initialize.selector, owner);
+        bytes memory initData = abi.encodeWithSelector(
+            MockRegistry.initialize.selector,
+            owner
+        );
 
         // deploy proxy
         vm.prank(owner);
-        address proxyAddress = factory.deployProxy(address(implementation), salt, initData);
+        address proxyAddress = factory.deployProxy(
+            address(implementation),
+            salt,
+            initData
+        );
 
         // initialize v1 implementation
         MockRegistry proxyV1 = MockRegistry(proxyAddress);
@@ -186,8 +281,15 @@ contract VerifiableFactoryTest is Test {
         // register an address
         vm.prank(owner);
         proxyV1.register(testAccount);
-        assertTrue(proxyV1.registeredAddresses(testAccount), "Address should be registered in V1");
-        assertEq(proxyV1.getRegistryVersion(), 1, "Should be V1 implementation");
+        assertTrue(
+            proxyV1.registeredAddresses(testAccount),
+            "Address should be registered in V1"
+        );
+        assertEq(
+            proxyV1.getRegistryVersion(),
+            1,
+            "Should be V1 implementation"
+        );
 
         // upgrade to v2
         vm.prank(owner);
@@ -200,46 +302,83 @@ contract VerifiableFactoryTest is Test {
         MockRegistryV2 proxyV2 = MockRegistryV2(proxyAddress);
 
         // check storage persistence
-        assertTrue(proxyV2.registeredAddresses(testAccount), "Address registration should persist after upgrade");
+        assertTrue(
+            proxyV2.registeredAddresses(testAccount),
+            "Address registration should persist after upgrade"
+        );
         assertEq(proxyV2.owner(), owner, "Owner should persist after upgrade");
-        assertEq(proxyV2.getRegistryVersion(), 2, "Should be V2 implementation");
+        assertEq(
+            proxyV2.getRegistryVersion(),
+            2,
+            "Should be V2 implementation"
+        );
 
         // verify v2 functionality still works as it should be
         address newTestAccount = makeAddr("newTestAccount");
         vm.prank(owner);
         proxyV2.register(newTestAccount);
-        assertTrue(proxyV2.registeredAddresses(newTestAccount), "Should be able to register new address in V2");
+        assertTrue(
+            proxyV2.registeredAddresses(newTestAccount),
+            "Should be able to register new address in V2"
+        );
 
         address newTestAccount2 = makeAddr("newTestAccount2");
         vm.prank(maliciousUser);
-        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, maliciousUser));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
+                maliciousUser
+            )
+        );
         proxyV2.register(newTestAccount2);
     }
 
     function test_ProxyOwner() public {
         uint256 salt = 1;
 
-        bytes memory initData = abi.encodeWithSelector(MockRegistry.initialize.selector, owner);
+        bytes memory initData = abi.encodeWithSelector(
+            MockRegistry.initialize.selector,
+            owner
+        );
 
         vm.prank(owner);
-        address proxyAddress = factory.deployProxy(address(implementation), salt, initData);
+        address proxyAddress = factory.deployProxy(
+            address(implementation),
+            salt,
+            initData
+        );
 
         // test proxy state
         UUPSProxy proxy = UUPSProxy(payable(proxyAddress));
         MockRegistry proxyRegistryV1 = MockRegistry(proxyAddress);
 
         bytes32 computedSalt = keccak256(abi.encode(owner, salt));
-        assertEq(proxy.getVerifiableProxySalt(), computedSalt, "Wrong proxy salt");
+        assertEq(
+            proxy.getVerifiableProxySalt(),
+            computedSalt,
+            "Wrong proxy salt"
+        );
         assertEq(proxyRegistryV1.owner(), owner, "Wrong proxyRegistryV1 owner");
-        assertEq(proxy.verifiableProxyFactory(), address(factory), "Wrong proxy factory");
+        assertEq(
+            proxy.verifiableProxyFactory(),
+            address(factory),
+            "Wrong proxy factory"
+        );
     }
 
     function test_StorageCollision() public {
         uint256 salt = 1;
-        bytes memory initData = abi.encodeWithSelector(MockRegistry.initialize.selector, owner);
+        bytes memory initData = abi.encodeWithSelector(
+            MockRegistry.initialize.selector,
+            owner
+        );
         // deploy proxy
         vm.prank(owner);
-        address proxy = factory.deployProxy(address(implementation), salt, initData);
+        address proxy = factory.deployProxy(
+            address(implementation),
+            salt,
+            initData
+        );
 
         // upgrade to conflicting layout
         StorageConflictImplementation conflict = new StorageConflictImplementation();
@@ -247,20 +386,33 @@ contract VerifiableFactoryTest is Test {
         MockRegistry(proxy).upgradeToAndCall(address(conflict), "");
 
         // execute dangerous storage manipulation
-        StorageConflictImplementation conflictedProxy = StorageConflictImplementation(proxy);
+        StorageConflictImplementation conflictedProxy = StorageConflictImplementation(
+                proxy
+            );
         conflictedProxy.dangerousMethod();
 
         // verify critical storage slots maintained
         UUPSProxy proxyInstance = UUPSProxy(payable(proxy));
-        assertEq(proxyInstance.verifiableProxyFactory(), address(factory), "Factory ref corrupted");
-        assertEq(proxyInstance.getVerifiableProxySalt(), keccak256(abi.encode(owner, salt)), "Salt ref corrupted");
+        assertEq(
+            proxyInstance.verifiableProxyFactory(),
+            address(factory),
+            "Factory ref corrupted"
+        );
+        assertEq(
+            proxyInstance.getVerifiableProxySalt(),
+            keccak256(abi.encode(owner, salt)),
+            "Salt ref corrupted"
+        );
     }
 
     function testFuzz_VerifyContract(uint256 salt) public {
         // deploy implementation
         MockRegistry impl = new MockRegistry();
 
-        bytes memory initData = abi.encodeWithSelector(MockRegistry.initialize.selector, owner);
+        bytes memory initData = abi.encodeWithSelector(
+            MockRegistry.initialize.selector,
+            owner
+        );
 
         // deploy proxy
         vm.prank(owner);
@@ -271,7 +423,11 @@ contract VerifiableFactoryTest is Test {
         assertTrue(verified, "Fuzz verification failed");
 
         // additional safety assertions
-        assertEq(IUUPSProxy(proxy).verifiableProxyFactory(), address(factory), "Factory relationship broken");
+        assertEq(
+            IUUPSProxy(proxy).verifiableProxyFactory(),
+            address(factory),
+            "Factory relationship broken"
+        );
         assertTrue(isContract(proxy), "Proxy must be valid contract");
     }
 
@@ -284,11 +440,21 @@ contract VerifiableFactoryTest is Test {
         return size > 0;
     }
 
-    function computeExpectedAddress(uint256 salt) internal view returns (address) {
+    function computeExpectedAddress(
+        uint256 salt
+    ) internal view returns (address) {
         bytes32 outerSalt = keccak256(abi.encode(owner, salt));
 
-        bytes memory bytecode = abi.encodePacked(type(UUPSProxy).creationCode, abi.encode(address(factory), outerSalt));
+        bytes memory bytecode = abi.encodePacked(
+            type(UUPSProxy).creationCode,
+            abi.encode(address(factory), outerSalt)
+        );
 
-        return Create2.computeAddress(outerSalt, keccak256(bytecode), address(factory));
+        return
+            Create2.computeAddress(
+                outerSalt,
+                keccak256(bytecode),
+                address(factory)
+            );
     }
 }

--- a/test/VerifiableFactory.t.sol
+++ b/test/VerifiableFactory.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {Test, console2} from "forge-std/Test.sol";
 import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 import {OwnableUpgradeable, Initializable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {ERC1967Utils} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
 
 import {VerifiableFactory} from "../src/VerifiableFactory.sol";
 import {IVerifiableFactory} from "../src/IVerifiableFactory.sol";
@@ -87,6 +88,16 @@ contract VerifiableFactoryTest is Test {
         vm.expectRevert(bytes(""));
         factory.deployProxy(address(implementation), salt, emptyData);
 
+        vm.stopPrank();
+    }
+
+    function test_DeployProxyWithEmptyBytecode() public {
+        uint256 salt = 1;
+        vm.startPrank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(ERC1967Utils.ERC1967InvalidImplementation.selector, address(maliciousUser))
+        );
+        factory.deployProxy(address(maliciousUser), salt, emptyData);
         vm.stopPrank();
     }
 

--- a/test/VerifiableFactory.t.sol
+++ b/test/VerifiableFactory.t.sol
@@ -274,7 +274,7 @@ contract VerifiableFactoryTest is Test {
         MockRegistry proxyRegistryV1 = MockRegistry(proxyAddress);
 
         bytes32 computedSalt = keccak256(abi.encode(owner, salt));
-        (bytes32 actualSalt,) = proxy.getVerifiableProxyData();
+        (bytes32 actualSalt, ) = proxy.getVerifiableProxyData();
         assertEq(actualSalt, computedSalt, "Wrong proxy salt");
         assertEq(proxyRegistryV1.owner(), owner, "Wrong proxyRegistryV1 owner");
         assertEq(proxy.verifiableProxyFactory(), address(factory), "Wrong proxy factory");
@@ -299,7 +299,7 @@ contract VerifiableFactoryTest is Test {
         // verify critical storage slots maintained
         UUPSProxy proxyInstance = UUPSProxy(payable(proxy));
         assertEq(proxyInstance.verifiableProxyFactory(), address(factory), "Factory ref corrupted");
-        (bytes32 actualSalt,) = proxyInstance.getVerifiableProxyData();
+        (bytes32 actualSalt, ) = proxyInstance.getVerifiableProxyData();
         assertEq(actualSalt, keccak256(abi.encode(owner, salt)), "Salt ref corrupted");
     }
 

--- a/test/VerifiableFactory.t.sol
+++ b/test/VerifiableFactory.t.sol
@@ -6,6 +6,7 @@ import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 import {OwnableUpgradeable, Initializable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 import {VerifiableFactory} from "../src/VerifiableFactory.sol";
+import {IVerifiableFactory} from "../src/IVerifiableFactory.sol";
 import {UUPSProxy} from "../src/UUPSProxy.sol";
 import {IUUPSProxy} from "../src/IUUPSProxy.sol";
 import {MockRegistry} from "../src/mock/MockRegistry.sol";
@@ -69,7 +70,9 @@ contract VerifiableFactoryTest is Test {
         // verify proxy state
         UUPSProxy proxy = UUPSProxy(payable(proxyAddress));
         bytes32 computedSalt = keccak256(abi.encode(owner, salt));
-        assertEq(proxy.getVerifiableProxySalt(), computedSalt, "Proxy salt mismatch");
+        (bytes32 actualSalt, address actualImplementation) = proxy.getVerifiableProxyData();
+        assertEq(actualSalt, computedSalt, "Proxy salt mismatch");
+        assertEq(actualImplementation, address(implementation), "Implementation mismatch");
         assertEq(proxy.verifiableProxyFactory(), address(factory), "Proxy factory mismatch");
     }
 
@@ -159,14 +162,27 @@ contract VerifiableFactoryTest is Test {
 
         vm.prank(owner);
         // verify the contract
-        bool isVerified = factory.verifyContract(proxyAddress);
+        bool isVerified = factory.verifyContract(proxyAddress, address(implementation));
         assertTrue(isVerified, "Contract verification failed");
 
         vm.prank(owner);
         // try to verify non-existent contract
         address randomAddress = makeAddr("random");
-        bool shouldBeFalse = factory.verifyContract(randomAddress);
+        bool shouldBeFalse = factory.verifyContract(randomAddress, address(implementation));
         assertFalse(shouldBeFalse, "Non-existent contract should not verify");
+    }
+
+    function test_VerifyContract_WrongImplementation() public {
+        uint256 salt = 1;
+
+        // deploy proxy
+        vm.prank(owner);
+        address proxyAddress = factory.deployProxy(address(implementation), salt, emptyData);
+
+        vm.prank(owner);
+        // verify the contract
+        bool isVerified = factory.verifyContract(proxyAddress, address(implementationV2));
+        assertFalse(isVerified, "Contract verification should fail");
     }
 
     function test_ProxyInitialization() public {
@@ -180,7 +196,9 @@ contract VerifiableFactoryTest is Test {
         UUPSProxy proxy = UUPSProxy(payable(proxyAddress));
 
         bytes32 computedSalt = keccak256(abi.encode(owner, salt));
-        assertEq(proxy.getVerifiableProxySalt(), computedSalt, "Wrong salt");
+        (bytes32 actualSalt, address actualImplementation) = proxy.getVerifiableProxyData();
+        assertEq(actualSalt, computedSalt, "Wrong salt");
+        assertEq(actualImplementation, address(implementation), "Wrong implementation");
         assertEq(proxy.verifiableProxyFactory(), address(factory), "Wrong factory");
     }
 
@@ -245,7 +263,8 @@ contract VerifiableFactoryTest is Test {
         MockRegistry proxyRegistryV1 = MockRegistry(proxyAddress);
 
         bytes32 computedSalt = keccak256(abi.encode(owner, salt));
-        assertEq(proxy.getVerifiableProxySalt(), computedSalt, "Wrong proxy salt");
+        (bytes32 actualSalt, ) = proxy.getVerifiableProxyData();
+        assertEq(actualSalt, computedSalt, "Wrong proxy salt");
         assertEq(proxyRegistryV1.owner(), owner, "Wrong proxyRegistryV1 owner");
         assertEq(proxy.verifiableProxyFactory(), address(factory), "Wrong proxy factory");
     }
@@ -269,7 +288,8 @@ contract VerifiableFactoryTest is Test {
         // verify critical storage slots maintained
         UUPSProxy proxyInstance = UUPSProxy(payable(proxy));
         assertEq(proxyInstance.verifiableProxyFactory(), address(factory), "Factory ref corrupted");
-        assertEq(proxyInstance.getVerifiableProxySalt(), keccak256(abi.encode(owner, salt)), "Salt ref corrupted");
+        (bytes32 actualSalt, ) = proxyInstance.getVerifiableProxyData();
+        assertEq(actualSalt, keccak256(abi.encode(owner, salt)), "Salt ref corrupted");
     }
 
     function testFuzz_VerifyContract(uint256 salt) public {
@@ -283,7 +303,7 @@ contract VerifiableFactoryTest is Test {
         address proxy = factory.deployProxy(address(impl), salt, initData);
 
         // verification checks
-        bool verified = factory.verifyContract(proxy);
+        bool verified = factory.verifyContract(proxy, address(impl));
         assertTrue(verified, "Fuzz verification failed");
 
         // additional safety assertions

--- a/test/VerifiableFactory.t.sol
+++ b/test/VerifiableFactory.t.sol
@@ -99,7 +99,7 @@ contract VerifiableFactoryTest is Test {
 
         // try to upgrade as non-owner (should fail)
         vm.prank(maliciousUser);
-        vm.expectRevert("Not authorized to upgrade");
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, maliciousUser));
         proxyV1.upgradeToAndCall(
             address(implementationV2),
             "" // add upgrade data if we need

--- a/test/VerifiableFactory.t.sol
+++ b/test/VerifiableFactory.t.sol
@@ -274,7 +274,7 @@ contract VerifiableFactoryTest is Test {
         MockRegistry proxyRegistryV1 = MockRegistry(proxyAddress);
 
         bytes32 computedSalt = keccak256(abi.encode(owner, salt));
-        (bytes32 actualSalt, ) = proxy.getVerifiableProxyData();
+        (bytes32 actualSalt,) = proxy.getVerifiableProxyData();
         assertEq(actualSalt, computedSalt, "Wrong proxy salt");
         assertEq(proxyRegistryV1.owner(), owner, "Wrong proxyRegistryV1 owner");
         assertEq(proxy.verifiableProxyFactory(), address(factory), "Wrong proxy factory");
@@ -299,7 +299,7 @@ contract VerifiableFactoryTest is Test {
         // verify critical storage slots maintained
         UUPSProxy proxyInstance = UUPSProxy(payable(proxy));
         assertEq(proxyInstance.verifiableProxyFactory(), address(factory), "Factory ref corrupted");
-        (bytes32 actualSalt, ) = proxyInstance.getVerifiableProxyData();
+        (bytes32 actualSalt,) = proxyInstance.getVerifiableProxyData();
         assertEq(actualSalt, keccak256(abi.encode(owner, salt)), "Salt ref corrupted");
     }
 

--- a/test/VerifiableFactory.t.sol
+++ b/test/VerifiableFactory.t.sol
@@ -3,10 +3,7 @@ pragma solidity ^0.8.20;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
-import {
-    OwnableUpgradeable,
-    Initializable
-} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {OwnableUpgradeable, Initializable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 import {VerifiableFactory} from "../src/VerifiableFactory.sol";
 import {UUPSProxy} from "../src/UUPSProxy.sol";
@@ -14,9 +11,7 @@ import {IUUPSProxy} from "../src/IUUPSProxy.sol";
 import {MockRegistry} from "../src/mock/MockRegistry.sol";
 import {MockRegistryV2} from "../src/mock/MockRegistryV2.sol";
 import {NonUUPSImpl} from "../src/mock/NonUUPSImpl.sol";
-import {
-    StorageConflictImplementation
-} from "../src/mock/StorageCollusionImpl.sol";
+import {StorageConflictImplementation} from "../src/mock/StorageCollusionImpl.sol";
 
 contract VerifiableFactoryTest is Test {
     // contract instances
@@ -32,12 +27,7 @@ contract VerifiableFactoryTest is Test {
     bytes emptyData;
 
     // ### Events
-    event ProxyDeployed(
-        address indexed sender,
-        address indexed proxyAddress,
-        uint256 salt,
-        address implementation
-    );
+    event ProxyDeployed(address indexed sender, address indexed proxyAddress, uint256 salt, address implementation);
 
     function setUp() public {
         owner = makeAddr("owner");
@@ -57,10 +47,7 @@ contract VerifiableFactoryTest is Test {
 
     function test_FactoryInitialState() public view {
         assertTrue(address(factory) != address(0), "Factory deployment failed");
-        assertTrue(
-            address(implementation) != address(0),
-            "Implementation deployment failed"
-        );
+        assertTrue(address(implementation) != address(0), "Implementation deployment failed");
     }
 
     function test_DeployProxy() public {
@@ -68,42 +55,22 @@ contract VerifiableFactoryTest is Test {
 
         // test event emit
         vm.expectEmit(true, true, true, true);
-        emit ProxyDeployed(
-            owner,
-            computeExpectedAddress(salt),
-            salt,
-            address(implementation)
-        );
+        emit ProxyDeployed(owner, computeExpectedAddress(salt), salt, address(implementation));
 
         vm.startPrank(owner);
-        address proxyAddress = factory.deployProxy(
-            address(implementation),
-            salt,
-            emptyData
-        );
+        address proxyAddress = factory.deployProxy(address(implementation), salt, emptyData);
 
         vm.stopPrank();
 
         // verify proxy deployment
-        assertTrue(
-            proxyAddress != address(0),
-            "Proxy address should not be zero"
-        );
+        assertTrue(proxyAddress != address(0), "Proxy address should not be zero");
         assertTrue(isContract(proxyAddress), "Proxy should be a contract");
 
         // verify proxy state
         UUPSProxy proxy = UUPSProxy(payable(proxyAddress));
         bytes32 computedSalt = keccak256(abi.encode(owner, salt));
-        assertEq(
-            proxy.getVerifiableProxySalt(),
-            computedSalt,
-            "Proxy salt mismatch"
-        );
-        assertEq(
-            proxy.verifiableProxyFactory(),
-            address(factory),
-            "Proxy factory mismatch"
-        );
+        assertEq(proxy.getVerifiableProxySalt(), computedSalt, "Proxy salt mismatch");
+        assertEq(proxy.verifiableProxyFactory(), address(factory), "Proxy factory mismatch");
     }
 
     function test_DeployProxyWithSameSalt() public {
@@ -123,17 +90,10 @@ contract VerifiableFactoryTest is Test {
     function test_UpgradeImplementation() public {
         uint256 salt = 1;
 
-        bytes memory initData = abi.encodeWithSelector(
-            MockRegistry.initialize.selector,
-            owner
-        );
+        bytes memory initData = abi.encodeWithSelector(MockRegistry.initialize.selector, owner);
         // deploy proxy as owner
         vm.prank(owner);
-        address proxyAddress = factory.deployProxy(
-            address(implementation),
-            salt,
-            initData
-        );
+        address proxyAddress = factory.deployProxy(address(implementation), salt, initData);
 
         MockRegistry proxyV1 = MockRegistry(proxyAddress);
 
@@ -154,31 +114,18 @@ contract VerifiableFactoryTest is Test {
 
         // verify new implementation
         MockRegistryV2 upgradedProxy = MockRegistryV2(proxyAddress);
-        assertEq(
-            upgradedProxy.getRegistryVersion(),
-            2,
-            "Implementation upgrade failed"
-        );
-        vm.expectRevert(
-            abi.encodeWithSelector(Initializable.InvalidInitialization.selector)
-        );
+        assertEq(upgradedProxy.getRegistryVersion(), 2, "Implementation upgrade failed");
+        vm.expectRevert(abi.encodeWithSelector(Initializable.InvalidInitialization.selector));
         upgradedProxy.initialize(owner);
     }
 
     function test_UpgradeToNonUUPS() public {
         uint256 salt = 1;
-        bytes memory initData = abi.encodeWithSelector(
-            MockRegistry.initialize.selector,
-            owner
-        );
+        bytes memory initData = abi.encodeWithSelector(MockRegistry.initialize.selector, owner);
 
         // Deploy proxy
         vm.prank(owner);
-        address proxyAddress = factory.deployProxy(
-            address(implementation),
-            salt,
-            initData
-        );
+        address proxyAddress = factory.deployProxy(address(implementation), salt, initData);
 
         // attempt upgrade to non-UUPS contract
         NonUUPSImpl badImpl = new NonUUPSImpl();
@@ -191,18 +138,11 @@ contract VerifiableFactoryTest is Test {
 
     function test_UpgradeToNonCompatibleImplementation() public {
         uint256 salt = 1;
-        bytes memory initData = abi.encodeWithSelector(
-            MockRegistry.initialize.selector,
-            owner
-        );
+        bytes memory initData = abi.encodeWithSelector(MockRegistry.initialize.selector, owner);
 
         // deploy proxy
         vm.prank(owner);
-        address proxyAddress = factory.deployProxy(
-            address(implementationV2),
-            salt,
-            initData
-        );
+        address proxyAddress = factory.deployProxy(address(implementationV2), salt, initData);
         MockRegistryV2 proxy = MockRegistryV2(proxyAddress);
 
         vm.prank(owner);
@@ -215,11 +155,7 @@ contract VerifiableFactoryTest is Test {
 
         // deploy proxy
         vm.prank(owner);
-        address proxyAddress = factory.deployProxy(
-            address(implementation),
-            salt,
-            emptyData
-        );
+        address proxyAddress = factory.deployProxy(address(implementation), salt, emptyData);
 
         vm.prank(owner);
         // verify the contract
@@ -238,40 +174,25 @@ contract VerifiableFactoryTest is Test {
 
         // deploy proxy
         vm.prank(owner);
-        address proxyAddress = factory.deployProxy(
-            address(implementation),
-            salt,
-            emptyData
-        );
+        address proxyAddress = factory.deployProxy(address(implementation), salt, emptyData);
 
         // test proxy state
         UUPSProxy proxy = UUPSProxy(payable(proxyAddress));
 
         bytes32 computedSalt = keccak256(abi.encode(owner, salt));
         assertEq(proxy.getVerifiableProxySalt(), computedSalt, "Wrong salt");
-        assertEq(
-            proxy.verifiableProxyFactory(),
-            address(factory),
-            "Wrong factory"
-        );
+        assertEq(proxy.verifiableProxyFactory(), address(factory), "Wrong factory");
     }
 
     function test_StoragePersistenceAfterUpgrade() public {
         uint256 salt = 1;
         address testAccount = makeAddr("testAccount");
 
-        bytes memory initData = abi.encodeWithSelector(
-            MockRegistry.initialize.selector,
-            owner
-        );
+        bytes memory initData = abi.encodeWithSelector(MockRegistry.initialize.selector, owner);
 
         // deploy proxy
         vm.prank(owner);
-        address proxyAddress = factory.deployProxy(
-            address(implementation),
-            salt,
-            initData
-        );
+        address proxyAddress = factory.deployProxy(address(implementation), salt, initData);
 
         // initialize v1 implementation
         MockRegistry proxyV1 = MockRegistry(proxyAddress);
@@ -281,15 +202,8 @@ contract VerifiableFactoryTest is Test {
         // register an address
         vm.prank(owner);
         proxyV1.register(testAccount);
-        assertTrue(
-            proxyV1.registeredAddresses(testAccount),
-            "Address should be registered in V1"
-        );
-        assertEq(
-            proxyV1.getRegistryVersion(),
-            1,
-            "Should be V1 implementation"
-        );
+        assertTrue(proxyV1.registeredAddresses(testAccount), "Address should be registered in V1");
+        assertEq(proxyV1.getRegistryVersion(), 1, "Should be V1 implementation");
 
         // upgrade to v2
         vm.prank(owner);
@@ -302,83 +216,46 @@ contract VerifiableFactoryTest is Test {
         MockRegistryV2 proxyV2 = MockRegistryV2(proxyAddress);
 
         // check storage persistence
-        assertTrue(
-            proxyV2.registeredAddresses(testAccount),
-            "Address registration should persist after upgrade"
-        );
+        assertTrue(proxyV2.registeredAddresses(testAccount), "Address registration should persist after upgrade");
         assertEq(proxyV2.owner(), owner, "Owner should persist after upgrade");
-        assertEq(
-            proxyV2.getRegistryVersion(),
-            2,
-            "Should be V2 implementation"
-        );
+        assertEq(proxyV2.getRegistryVersion(), 2, "Should be V2 implementation");
 
         // verify v2 functionality still works as it should be
         address newTestAccount = makeAddr("newTestAccount");
         vm.prank(owner);
         proxyV2.register(newTestAccount);
-        assertTrue(
-            proxyV2.registeredAddresses(newTestAccount),
-            "Should be able to register new address in V2"
-        );
+        assertTrue(proxyV2.registeredAddresses(newTestAccount), "Should be able to register new address in V2");
 
         address newTestAccount2 = makeAddr("newTestAccount2");
         vm.prank(maliciousUser);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
-                maliciousUser
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, maliciousUser));
         proxyV2.register(newTestAccount2);
     }
 
     function test_ProxyOwner() public {
         uint256 salt = 1;
 
-        bytes memory initData = abi.encodeWithSelector(
-            MockRegistry.initialize.selector,
-            owner
-        );
+        bytes memory initData = abi.encodeWithSelector(MockRegistry.initialize.selector, owner);
 
         vm.prank(owner);
-        address proxyAddress = factory.deployProxy(
-            address(implementation),
-            salt,
-            initData
-        );
+        address proxyAddress = factory.deployProxy(address(implementation), salt, initData);
 
         // test proxy state
         UUPSProxy proxy = UUPSProxy(payable(proxyAddress));
         MockRegistry proxyRegistryV1 = MockRegistry(proxyAddress);
 
         bytes32 computedSalt = keccak256(abi.encode(owner, salt));
-        assertEq(
-            proxy.getVerifiableProxySalt(),
-            computedSalt,
-            "Wrong proxy salt"
-        );
+        assertEq(proxy.getVerifiableProxySalt(), computedSalt, "Wrong proxy salt");
         assertEq(proxyRegistryV1.owner(), owner, "Wrong proxyRegistryV1 owner");
-        assertEq(
-            proxy.verifiableProxyFactory(),
-            address(factory),
-            "Wrong proxy factory"
-        );
+        assertEq(proxy.verifiableProxyFactory(), address(factory), "Wrong proxy factory");
     }
 
     function test_StorageCollision() public {
         uint256 salt = 1;
-        bytes memory initData = abi.encodeWithSelector(
-            MockRegistry.initialize.selector,
-            owner
-        );
+        bytes memory initData = abi.encodeWithSelector(MockRegistry.initialize.selector, owner);
         // deploy proxy
         vm.prank(owner);
-        address proxy = factory.deployProxy(
-            address(implementation),
-            salt,
-            initData
-        );
+        address proxy = factory.deployProxy(address(implementation), salt, initData);
 
         // upgrade to conflicting layout
         StorageConflictImplementation conflict = new StorageConflictImplementation();
@@ -386,33 +263,20 @@ contract VerifiableFactoryTest is Test {
         MockRegistry(proxy).upgradeToAndCall(address(conflict), "");
 
         // execute dangerous storage manipulation
-        StorageConflictImplementation conflictedProxy = StorageConflictImplementation(
-                proxy
-            );
+        StorageConflictImplementation conflictedProxy = StorageConflictImplementation(proxy);
         conflictedProxy.dangerousMethod();
 
         // verify critical storage slots maintained
         UUPSProxy proxyInstance = UUPSProxy(payable(proxy));
-        assertEq(
-            proxyInstance.verifiableProxyFactory(),
-            address(factory),
-            "Factory ref corrupted"
-        );
-        assertEq(
-            proxyInstance.getVerifiableProxySalt(),
-            keccak256(abi.encode(owner, salt)),
-            "Salt ref corrupted"
-        );
+        assertEq(proxyInstance.verifiableProxyFactory(), address(factory), "Factory ref corrupted");
+        assertEq(proxyInstance.getVerifiableProxySalt(), keccak256(abi.encode(owner, salt)), "Salt ref corrupted");
     }
 
     function testFuzz_VerifyContract(uint256 salt) public {
         // deploy implementation
         MockRegistry impl = new MockRegistry();
 
-        bytes memory initData = abi.encodeWithSelector(
-            MockRegistry.initialize.selector,
-            owner
-        );
+        bytes memory initData = abi.encodeWithSelector(MockRegistry.initialize.selector, owner);
 
         // deploy proxy
         vm.prank(owner);
@@ -423,11 +287,7 @@ contract VerifiableFactoryTest is Test {
         assertTrue(verified, "Fuzz verification failed");
 
         // additional safety assertions
-        assertEq(
-            IUUPSProxy(proxy).verifiableProxyFactory(),
-            address(factory),
-            "Factory relationship broken"
-        );
+        assertEq(IUUPSProxy(proxy).verifiableProxyFactory(), address(factory), "Factory relationship broken");
         assertTrue(isContract(proxy), "Proxy must be valid contract");
     }
 
@@ -440,21 +300,11 @@ contract VerifiableFactoryTest is Test {
         return size > 0;
     }
 
-    function computeExpectedAddress(
-        uint256 salt
-    ) internal view returns (address) {
+    function computeExpectedAddress(uint256 salt) internal view returns (address) {
         bytes32 outerSalt = keccak256(abi.encode(owner, salt));
 
-        bytes memory bytecode = abi.encodePacked(
-            type(UUPSProxy).creationCode,
-            abi.encode(address(factory), outerSalt)
-        );
+        bytes memory bytecode = abi.encodePacked(type(UUPSProxy).creationCode, abi.encode(address(factory), outerSalt));
 
-        return
-            Create2.computeAddress(
-                outerSalt,
-                keccak256(bytecode),
-                address(factory)
-            );
+        return Create2.computeAddress(outerSalt, keccak256(bytecode), address(factory));
     }
 }


### PR DESCRIPTION
we want to ensure that there is a trusted upgrade path when upgrading a proxy's implementation. this is because a user could initialize with an implementation that modifies storage slots, and then upgrade to a known implementation (e.g. registry), which could cause behaviour that is impossible otherwise.

to effectively implement a trusted upgrade path the new implementation should be able to determine if the previous implementation was trusted before an upgrade, to ensure a chain of trust. outside of the `upgradeToAndCall` function, an implementation should also never be able to change the value of the implementation slot.

changes:
- added an `IProxyAuthorization` interface which includes
  - `canUpgradeFrom(address previousImplementation)`: to be called on the new implementation, ensuring a chain of trust
- UUPSProxy:
  - now implements a pre-check for `upgradeToAndCall`, which will call `canUpgradeFrom` on the new implementation. it falls through to the existing implementation's `upgradeToAndCall` to ensure existing permissions/errors are maintained.
  - always checks for a modified implementation slot on all `_delegate` calls

Fixes BET-450

[review]
changes:
- VerifiableFactory:
  - added `IVerifiableFactory` interface
  - removed contract bytecode size check in `deployProxy` — the error is unreachable as `proxy.initialize` will always check bytecode size via `ERC1967Utils.upgradeToAndCall`
  - modified `verifyContract` function to take an expected implementation address. alternatively, it could just return the implementation address so the client can determine if it's valid.
- UUPSProxy:
  - changed `getVerifiableProxySalt() returns (bytes32)` to `getVerifiableProxyData() returns (bytes32 salt, address implementation)` - for `verifyContract` api change
