### PR TITLE
feat: 1167-style clone proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,169 +1,112 @@
-# Verifiable Factory Contract
+# Verifiable Factory
 
-A system for deploying and verifying proxy contracts with predictable storage layouts and deterministic addresses using CREATE2.
+This repo contains a `CREATE2` factory for deterministic, verifiable, UUPS-compatible proxy clones.
 
-## Components
-
-### 1. Verifiable Factory Contract
-- Deploys Verifiable UUPSProxy instances using CREATE2 opcode
-- Handles on-chain verification of deployed proxies
-- Manages proxy upgrades through a secure ownership model
-- Uses deterministic salt generation for predictable addresses
-
-### 2. Verifiable UUPSProxy
-- UUPS proxy pattern with verified storage layout
-- Fixed storage slots via [SlotDerivation](https://docs.openzeppelin.com/contracts/5.x/api/utils#SlotDerivation) under `proxy.verifiable` namespace
-  - `salt` (uint256)
-- Immutable `verifiableProxyFactory` field (set in bytecode)
-- Implements secure upgrade mechanism via UUPSUpgradable
-- Initializable to prevent implementation tampering
-
-## Architecture
+The factory deploys one shared `UUPSProxyLogic` contract. Each proxy is a minimal clone that delegates proxy bookkeeping to that shared logic, while keeping its own ERC-1967 implementation slot. The clone runtime also carries the derived salt, which lets the factory verify later that a proxy address came from this factory.
 
 ```mermaid
 sequenceDiagram
-    participant User
-    participant VerifiableFactory
-    participant UUPSProxy
-    participant Implementation
+    participant Caller
+    participant Factory as VerifiableFactory
+    participant Clone as Proxy clone
+    participant Logic as UUPSProxyLogic
+    participant Impl as Implementation
 
-    %% Deployment Flow
-    User->>VerifiableFactory: deployProxy(implementation, salt)
-    VerifiableFactory->>VerifiableFactory: Generate outerSalt (keccak256(sender, salt))
-    VerifiableFactory->>UUPSProxy: CREATE2 deployment
-    UUPSProxy->>UUPSProxy: Set immutable factory address
-    VerifiableFactory->>UUPSProxy: initialize(outerSalt, implementation)
-    UUPSProxy->>Implementation: Delegate calls
-    VerifiableFactory->>User: Return proxy address
-
-    %% Verification Flow
-    User->>VerifiableFactory: verifyContract(proxyAddress)
-    VerifiableFactory->>UUPSProxy: Check contract existence
-    VerifiableFactory->>UUPSProxy: Query salt and factory address
-    VerifiableFactory->>VerifiableFactory: Reconstruct CREATE2 address
-    VerifiableFactory->>User: Return verification result
-
-    %% Upgrade Flow
-    User->>UUPSProxy: upgradeToAndCall(newImpl, data)
-    UUPSProxy->>Implementation: fallback to UUPSUpgradable upgradeToAndCall(newImpl, data)
-    Implementation->>Implementation: Check caller is owner
-    Implementation->>Implementation: Switch delegation target
+    Caller->>Factory: deployProxy(implementation, salt, data)
+    Factory->>Clone: CREATE2 clone(proxyLogic, outerSalt)
+    Factory->>Clone: initialize(implementation, data)
+    Clone->>Logic: delegatecall
+    Logic->>Impl: delegatecall data
+    Caller->>Clone: application call / ETH transfer
+    Clone->>Logic: delegatecall
+    Logic->>Impl: delegatecall
 ```
 
-## Implementation Guide
+## Deploying
 
-### Requirements
-1. Inherit UUPS compliance:
+`deployProxy(implementation, salt, data)` does four things:
+
+- derives `outerSalt = keccak256(abi.encode(msg.sender, salt))`
+- deploys clone bytecode for `factory.proxyLogic()` with `outerSalt` appended to the runtime
+- stores `implementation` in the clone's ERC-1967 implementation slot
+- delegatecalls `data` into `implementation` if `data` is nonempty
+
+The proxy address is deterministic for a given factory, shared logic address, caller, and user salt:
+
 ```solidity
-import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-
-contract MyContract is UUPSUpgradeable {
-
-  // ..rest of your own implementation
+bytes32 outerSalt = keccak256(abi.encode(caller, userSalt));
+bytes memory bytecode = CloneProxyBytecode.creationCode(factory.proxyLogic(), outerSalt);
+address proxy = Create2.computeAddress(outerSalt, keccak256(bytecode), address(factory));
 ```
 
-2. Use initializer instead of constructor:
-```solidity
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+The caller is part of `outerSalt`, so two callers can use the same user salt without colliding.
 
-contract MyContract is Initializable, UUPSUpgradeable {
-    // Implementation must follow UUPS upgrade pattern requirements
+## Verifying
 
-    function initialize() public initializer {
-        // Initialize inherited UUPS contract
-        __UUPSUpgradeable_init()
-    }
+`verifyContract(proxy, expectedImplementation)` checks that:
 
-    // ..rest of your own implementation
-```
+- `proxy` has code
+- `proxy` returns verifiable proxy data
+- the current implementation is `expectedImplementation`
+- the proxy address matches this factory's `CREATE2` derivation for the returned salt
 
-3. Implement upgrade authorization:
-```solidity
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+That proves the address was deployed by this factory and currently points at the expected implementation. It does not prove the implementation is safe, audited, storage-compatible with old versions, or still on its original implementation. After an upgrade, verify against the new current implementation.
 
-contract MyContract is UUPSUpgradeable, OwnableUpgradeable {
+## Implementations
 
-    // Mandatory security measure - define who can upgrade the contract
-    // This function is executed on the CURRENT implementation (old contract)
-    // during the upgrade process. It verifies permissions before switching implementations.
-    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
-
-    // ..rest of your own implementation
-```
-
-### Example Implementation
+Implementations should use OpenZeppelin `UUPSUpgradeable` and must implement `IProxyAuthorization`:
 
 ```solidity
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
-
-// Required UUPS imports
-import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-
-contract MyImplementationV1 is UUPSUpgradeable, OwnableUpgradeable {
-    
-    uint256 public value;
-
-    // Initialization replaces constructor functionality
-    function initialize(address owner, uint256 initialValue) public initializer {
-        // Initialize parent contracts first
-        __Ownable_init(owner);       // Sets initial owner
-        __UUPSUpgradeable_init();    // Required UUPS initialization
-        
-        // Custom initialization logic
-        value = initialValue;
-    }
-
-    // Critical security function - defines upgrade permissions
-    // Using onlyOwner modifier ensures only the designated owner can authorize contract upgrades
-    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
-
-    // ..rest of your own implementation
+interface IProxyAuthorization {
+    function canUpgradeFrom(address previousImplementation) external view returns (bool);
 }
 ```
 
-### Example Implementation Upgrade
+There are two upgrade checks:
+
+- the current implementation's UUPS `_authorizeUpgrade` decides who can upgrade
+- the new implementation's `canUpgradeFrom(currentImplementation)` says whether this upgrade path is allowed
+
+Usually `canUpgradeFrom` is just an allowlist of previous implementation addresses:
 
 ```solidity
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+contract MyImplementation is UUPSUpgradeable, OwnableUpgradeable, IProxyAuthorization {
+    address public allowedPreviousImplementation;
+    uint256[49] private __gap;
 
-import "./MyImplementationV1.sol";
-
-contract MyImplementationV2 is MyImplementationV1 {
-
-    uint256 public value;
-    
-    function postUpgradeSetup(uint256 upgradedValue) external onlyOwner {
-        value = upgradedValue;
+    function initialize(address owner) public initializer {
+        __Ownable_init(owner);
+        __UUPSUpgradeable_init();
     }
+
+    function canUpgradeFrom(address previousImplementation) external view returns (bool) {
+        return previousImplementation == allowedPreviousImplementation;
+    }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
 }
 ```
 
-### Post-Upgrade Hooks
+## Trust Model
 
-To execute logic after an upgrade, use `data` parameter in `upgradeToAndCall` pattern.
+An authorized upgrade means you trust both the new implementation and the `upgradeToAndCall` payload. The post-upgrade hook runs with `delegatecall` in the proxy's storage context, so it can write any proxy storage slot, including ERC-1967 slots.
 
-The `upgradeToAndCall` pattern allows executing any function on the new implementation:
-- Calls are made via `DELEGATECALL` from the proxy, so `msg.sender` will refer to the original sender in hook functions, while `address(this)` will refer to the proxy address.
-- Storage modifications affect the proxy's state
-- Caller must follow the authorization rules as implemented in the implementation contract
+Normal application calls are stricter. `UUPSProxyLogic` checks the ERC-1967 implementation slot after non-upgrade fallback calls and reverts if the implementation changed.
 
-```solidity
-// initial values based on example implementation
-// address owner = address(0x..)
-// uint256 initialValue = 6174; 
+## Storage
 
-// In your deploy script
-bytes memory initData = abi.encodeWithSelector(MyImplementationV1.initialize.selector, owner, initialValue);
-address proxyAddress = factory.deployProxy(address(implementation), salt, initData);
+The implementation address uses the standard ERC-1967 slot:
 
-MockRegistryV1 proxyV1 = MockRegistryV1(proxyAddress);
+```text
+0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc
+```
 
-// uint256 upgradedValue = 1729;
+The verification salt is not stored in proxy storage. It is appended to the clone runtime bytecode and returned by `getVerifiableProxyData()`.
 
-// In your upgrade script (owner wallet calls)
-bytes memory callData = abi.encodeWithSelector(MyImplementationV2.postUpgradeSetup.selector, upgradedValue);
-proxyV1.upgradeToAndCall(address(newImplementation), callData);
+Implementation upgrades still need normal upgradeable-contract storage layout discipline: append new variables instead of reordering existing ones, and use storage gaps or namespaced storage for contracts that may need future base-contract storage.
+
+## Development
+
+```sh
+forge test
 ```

--- a/src/CloneProxyBytecode.sol
+++ b/src/CloneProxyBytecode.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+library CloneProxyBytecode {
+    // EIP-1167 minimal proxy creation/runtime code:
+    // https://eips.ethereum.org/EIPS/eip-1167
+    //
+    // Standard runtime is 45 bytes:
+    // 363d3d373d3d3d363d73<20-byte implementation>5af43d82803e903d91602b57fd5bf3
+    //
+    // We append a 32-byte salt to the runtime and make the creation stub return 77 bytes
+    // instead of the standard 45. The proxy still executes the same minimal-proxy logic;
+    // UUPSProxyLogic reads the appended salt with extcodecopy().
+    uint256 internal constant CREATION_CODE_LENGTH = 0x57;
+
+    function creationCode(address logic, bytes32 salt) internal pure returns (bytes memory code) {
+        code = new bytes(CREATION_CODE_LENGTH);
+
+        assembly ("memory-safe") {
+            let ptr := add(code, 0x20)
+
+            // Creation stub plus runtime prefix. The creation stub returns 77 bytes:
+            // 45 bytes of EIP-1167 runtime plus our appended 32-byte salt.
+            mstore(ptr, 0x3d604d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
+            // Fill the EIP-1167 PUSH20 slot with the shared proxy logic address.
+            mstore(add(ptr, 0x14), shl(0x60, logic))
+            // Runtime suffix: delegatecall to `logic`, copy returndata, then return or revert.
+            mstore(add(ptr, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
+            // Append salt after the executable minimal-proxy runtime for extcodecopy().
+            mstore(add(ptr, 0x37), salt)
+        }
+    }
+}

--- a/src/IUUPSProxy.sol
+++ b/src/IUUPSProxy.sol
@@ -12,6 +12,8 @@ interface IUUPSProxy {
 
     error UpgradeNotAllowedInContext();
 
+    function initialize(address implementation, bytes calldata data) external payable;
+
     function getVerifiableProxyData() external view returns (bytes32 salt, address implementation);
 
     function verifiableProxyFactory() external view returns (address);

--- a/src/UUPSProxyLogic.sol
+++ b/src/UUPSProxyLogic.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IProxyAuthorization} from "./IProxyAuthorization.sol";
+import {IUUPSProxy} from "./IUUPSProxy.sol";
+
+contract UUPSProxyLogic is IUUPSProxy {
+    /// @dev `keccak256(bytes("eip1967.proxy.implementation")) - 1`.
+    bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    /// @dev `bytes4(keccak256(bytes("ImplementationCannotBeZeroAddress()")))`.
+    uint256 internal constant _IMPLEMENTATION_CANNOT_BE_ZERO_ADDRESS_ERROR_SELECTOR = 0x0760838f;
+
+    /// @dev `bytes4(keccak256(bytes("AlreadyInitialized()")))`.
+    uint256 internal constant _ALREADY_INITIALIZED_ERROR_SELECTOR = 0x0dc149f0;
+
+    /// @dev `bytes4(keccak256(bytes("UpgradeNotAllowedInContext()")))`.
+    uint256 internal constant _UPGRADE_NOT_ALLOWED_IN_CONTEXT_ERROR_SELECTOR = 0x784cf700;
+
+    /// @dev `bytes4(keccak256(bytes("ERC1967InvalidImplementation(address)")))`.
+    uint256 internal constant _ERC1967_INVALID_IMPLEMENTATION_ERROR_SELECTOR = 0x4c9c8ce3;
+
+    /// @dev `bytes4(keccak256(bytes("ERC1967NonPayable()")))`.
+    uint256 internal constant _ERC1967_NON_PAYABLE_ERROR_SELECTOR = 0xb398979f;
+
+    /// @dev `bytes4(keccak256(bytes("Upgraded(address)")))`.
+    uint256 internal constant _UPGRADED_EVENT_SELECTOR =
+        0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b;
+
+    address public immutable verifiableProxyFactory;
+
+    constructor() {
+        verifiableProxyFactory = msg.sender;
+    }
+
+    function initialize(address implementation, bytes calldata data) external payable {
+        assembly {
+            if eq(implementation, 0) {
+                mstore(0, _IMPLEMENTATION_CANNOT_BE_ZERO_ADDRESS_ERROR_SELECTOR)
+                revert(0x1c, 0x04)
+            }
+            if iszero(eq(sload(_IMPLEMENTATION_SLOT), 0)) {
+                mstore(0, _ALREADY_INITIALIZED_ERROR_SELECTOR)
+                revert(0x1c, 0x04)
+            }
+            if iszero(extcodesize(implementation)) {
+                mstore(0, _ERC1967_INVALID_IMPLEMENTATION_ERROR_SELECTOR)
+                mstore(0x20, implementation)
+                revert(0x1c, 0x24)
+            }
+            sstore(_IMPLEMENTATION_SLOT, implementation)
+            log2(0, 0, _UPGRADED_EVENT_SELECTOR, implementation)
+
+            let dlength := data.length
+            switch dlength
+            case 0 {
+                if callvalue() {
+                    mstore(0, _ERC1967_NON_PAYABLE_ERROR_SELECTOR)
+                    revert(0x1c, 0x04)
+                }
+            }
+            default {
+                calldatacopy(0, data.offset, dlength)
+                let result := delegatecall(gas(), implementation, 0, dlength, 0, 0)
+                if iszero(result) {
+                    returndatacopy(0, 0, returndatasize())
+                    revert(0, returndatasize())
+                }
+            }
+        }
+    }
+
+    function getVerifiableProxyData() public view returns (bytes32 salt, address implementation) {
+        assembly {
+            extcodecopy(address(), 0, sub(extcodesize(address()), 0x20), 0x20)
+            salt := mload(0)
+            implementation := sload(_IMPLEMENTATION_SLOT)
+        }
+    }
+
+    function upgradeToAndCall(address newImplementation, bytes calldata) external payable {
+        if (newImplementation == address(0)) revert ImplementationCannotBeZeroAddress();
+
+        address implementation = _implementation();
+        if (implementation == address(0)) revert ImplementationNotSet();
+
+        IProxyAuthorization newImpl = IProxyAuthorization(newImplementation);
+        if (!newImpl.canUpgradeFrom(implementation)) {
+            revert InvalidUpgradeTarget(implementation, newImplementation);
+        }
+
+        _delegate(implementation, false);
+    }
+
+    function _implementation() internal view returns (address impl) {
+        assembly {
+            impl := sload(_IMPLEMENTATION_SLOT)
+        }
+    }
+
+    function _delegate(address implementation, bool checkImplementation) internal {
+        assembly {
+            calldatacopy(0, 0, calldatasize())
+
+            let result := delegatecall(gas(), implementation, 0, calldatasize(), 0, 0)
+
+            if checkImplementation {
+                if iszero(eq(implementation, sload(_IMPLEMENTATION_SLOT))) {
+                    mstore(0, _UPGRADE_NOT_ALLOWED_IN_CONTEXT_ERROR_SELECTOR)
+                    revert(0x1c, 0x04)
+                }
+            }
+
+            returndatacopy(0, 0, returndatasize())
+
+            switch result
+            case 0 {
+                revert(0, returndatasize())
+            }
+            default {
+                return(0, returndatasize())
+            }
+        }
+    }
+
+    fallback() external payable {
+        _delegate(_implementation(), true);
+    }
+}

--- a/src/VerifiableFactory.sol
+++ b/src/VerifiableFactory.sol
@@ -3,37 +3,46 @@ pragma solidity ^0.8.20;
 
 import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 
-import {UUPSProxy} from "./UUPSProxy.sol";
+import {CloneProxyBytecode} from "./CloneProxyBytecode.sol";
+import {UUPSProxyLogic} from "./UUPSProxyLogic.sol";
 import {IUUPSProxy} from "./IUUPSProxy.sol";
 import {IVerifiableFactory} from "./IVerifiableFactory.sol";
 
 contract VerifiableFactory is IVerifiableFactory {
+    address public immutable proxyLogic;
+
+    constructor() {
+        proxyLogic = address(new UUPSProxyLogic());
+    }
+
     /**
-     * @dev Deploys a new `UUPSProxy` contract at a deterministic address.
+     * @dev Deploys a new verifiable proxy clone at a deterministic address.
      *
-     * This function deploys a proxy contract using the CREATE2 opcode, ensuring a predictable
-     * address based on the sender's address and a provided salt. The deployed proxy is
-     * controlled by the factory and is initialized to use a specific implementation.
+     * The deployed proxy is an EIP-1167-style clone that delegates proxy mechanics to the
+     * factory's `proxyLogic` contract. The clone runtime also appends the derived salt so the
+     * factory can later verify the proxy's CREATE2 address.
      *
-     * - A unique address for the proxy is generated using the caller's address and the salt.
-     * - After deployment, the proxy's `initialize` function is called to configure it with the given salt,
-     *   the factory address, and the provided implementation address.
-     * - The proxy is fully managed by the factory, which controls upgrades and other administrative methods.
-     * - The event `ProxyDeployed` is emitted, logging details of the deployment including the sender, proxy address, salt, and implementation.
+     * The CREATE2 salt is `keccak256(abi.encode(msg.sender, salt))`, so two callers can reuse
+     * the same user salt without colliding.
      *
      * @param implementation The address of the contract implementation the proxy will delegate calls to.
      * @param salt A value provided by the caller to ensure uniqueness of the proxy address.
-     * @return proxy The address of the deployed `UUPSProxy`.
+     * @return proxy The address of the deployed proxy clone.
      */
-    function deployProxy(address implementation, uint256 salt, bytes memory data) external returns (address) {
+    function deployProxy(address implementation, uint256 salt, bytes memory data) external returns (address proxy) {
         bytes32 outerSalt = keccak256(abi.encode(msg.sender, salt));
+        bytes memory executableBytecode = _proxyCreationCode(outerSalt);
 
-        UUPSProxy proxy = new UUPSProxy{salt: outerSalt}(address(this), outerSalt);
+        assembly {
+            proxy := create2(0, add(executableBytecode, 0x20), mload(executableBytecode), outerSalt)
+            if iszero(proxy) {
+                revert(0, 0)
+            }
+        }
 
-        proxy.initialize(implementation, data);
+        IUUPSProxy(proxy).initialize(implementation, data);
 
-        emit ProxyDeployed(msg.sender, address(proxy), salt, implementation);
-        return address(proxy);
+        emit ProxyDeployed(msg.sender, proxy, salt, implementation);
     }
 
     /**
@@ -57,12 +66,15 @@ contract VerifiableFactory is IVerifiableFactory {
     }
 
     function _verifyContract(address proxy, bytes32 salt) private view returns (bool) {
-        // get creation bytecode with constructor arguments
-        bytes memory bytecode = abi.encodePacked(type(UUPSProxy).creationCode, abi.encode(address(this), salt));
+        bytes memory proxyBytecode = _proxyCreationCode(salt);
 
-        address expectedProxyAddress = Create2.computeAddress(salt, keccak256(bytecode), address(this));
+        address expectedProxyAddress = Create2.computeAddress(salt, keccak256(proxyBytecode), address(this));
 
         return expectedProxyAddress == proxy;
+    }
+
+    function _proxyCreationCode(bytes32 salt) private view returns (bytes memory creationCode) {
+        creationCode = CloneProxyBytecode.creationCode(proxyLogic, salt);
     }
 
     function isContract(address account) internal view returns (bool) {

--- a/test/VerifiableFactory.t.sol
+++ b/test/VerifiableFactory.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {Test, console2} from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 import {OwnableUpgradeable, Initializable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {ERC1967Utils} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
 
+import {CloneProxyBytecode} from "../src/CloneProxyBytecode.sol";
 import {VerifiableFactory} from "../src/VerifiableFactory.sol";
 import {IVerifiableFactory} from "../src/IVerifiableFactory.sol";
-import {UUPSProxy} from "../src/UUPSProxy.sol";
 import {IUUPSProxy} from "../src/IUUPSProxy.sol";
 import {MockRegistry} from "../src/mock/MockRegistry.sol";
 import {MockRegistryV2} from "../src/mock/MockRegistryV2.sol";
@@ -49,6 +49,7 @@ contract VerifiableFactoryTest is Test {
 
     function test_FactoryInitialState() public view {
         assertTrue(address(factory) != address(0), "Factory deployment failed");
+        assertTrue(factory.proxyLogic() != address(0), "Proxy logic deployment failed");
         assertTrue(address(implementation) != address(0), "Implementation deployment failed");
     }
 
@@ -69,7 +70,7 @@ contract VerifiableFactoryTest is Test {
         assertTrue(isContract(proxyAddress), "Proxy should be a contract");
 
         // verify proxy state
-        UUPSProxy proxy = UUPSProxy(payable(proxyAddress));
+        IUUPSProxy proxy = IUUPSProxy(proxyAddress);
         bytes32 computedSalt = keccak256(abi.encode(owner, salt));
         (bytes32 actualSalt, address actualImplementation) = proxy.getVerifiableProxyData();
         assertEq(actualSalt, computedSalt, "Proxy salt mismatch");
@@ -204,13 +205,40 @@ contract VerifiableFactoryTest is Test {
         address proxyAddress = factory.deployProxy(address(implementation), salt, emptyData);
 
         // test proxy state
-        UUPSProxy proxy = UUPSProxy(payable(proxyAddress));
+        IUUPSProxy proxy = IUUPSProxy(proxyAddress);
 
         bytes32 computedSalt = keccak256(abi.encode(owner, salt));
         (bytes32 actualSalt, address actualImplementation) = proxy.getVerifiableProxyData();
         assertEq(actualSalt, computedSalt, "Wrong salt");
         assertEq(actualImplementation, address(implementation), "Wrong implementation");
         assertEq(proxy.verifiableProxyFactory(), address(factory), "Wrong factory");
+    }
+
+    function test_ProxyReceiveDelegatesToImplementation() public {
+        PayableReceiver receiver = new PayableReceiver();
+
+        vm.prank(owner);
+        address proxyAddress = factory.deployProxy(address(receiver), 1, emptyData);
+
+        vm.deal(user, 1 ether);
+        vm.prank(user);
+        (bool success,) = proxyAddress.call{value: 1}("");
+
+        assertTrue(success, "Receive should delegate to implementation");
+        assertEq(proxyAddress.balance, 1, "Proxy balance mismatch");
+        assertEq(PayableReceiver(payable(proxyAddress)).received(), 1, "Receive hook did not run");
+    }
+
+    function test_ProxyReceiveRevertsWhenImplementationRejectsEth() public {
+        vm.prank(owner);
+        address proxyAddress = factory.deployProxy(address(implementation), 1, emptyData);
+
+        vm.deal(user, 1 ether);
+        vm.prank(user);
+        (bool success,) = proxyAddress.call{value: 1}("");
+
+        assertFalse(success, "Receive should follow implementation payable behavior");
+        assertEq(proxyAddress.balance, 0, "Proxy should not retain rejected ETH");
     }
 
     function test_StoragePersistenceAfterUpgrade() public {
@@ -270,7 +298,7 @@ contract VerifiableFactoryTest is Test {
         address proxyAddress = factory.deployProxy(address(implementation), salt, initData);
 
         // test proxy state
-        UUPSProxy proxy = UUPSProxy(payable(proxyAddress));
+        IUUPSProxy proxy = IUUPSProxy(proxyAddress);
         MockRegistry proxyRegistryV1 = MockRegistry(proxyAddress);
 
         bytes32 computedSalt = keccak256(abi.encode(owner, salt));
@@ -297,7 +325,7 @@ contract VerifiableFactoryTest is Test {
         conflictedProxy.dangerousMethod();
 
         // verify critical storage slots maintained
-        UUPSProxy proxyInstance = UUPSProxy(payable(proxy));
+        IUUPSProxy proxyInstance = IUUPSProxy(proxy);
         assertEq(proxyInstance.verifiableProxyFactory(), address(factory), "Factory ref corrupted");
         (bytes32 actualSalt,) = proxyInstance.getVerifiableProxyData();
         assertEq(actualSalt, keccak256(abi.encode(owner, salt)), "Salt ref corrupted");
@@ -334,8 +362,16 @@ contract VerifiableFactoryTest is Test {
     function computeExpectedAddress(uint256 salt) internal view returns (address) {
         bytes32 outerSalt = keccak256(abi.encode(owner, salt));
 
-        bytes memory bytecode = abi.encodePacked(type(UUPSProxy).creationCode, abi.encode(address(factory), outerSalt));
+        bytes memory bytecode = CloneProxyBytecode.creationCode(factory.proxyLogic(), outerSalt);
 
         return Create2.computeAddress(outerSalt, keccak256(bytecode), address(factory));
+    }
+}
+
+contract PayableReceiver {
+    uint256 public received;
+
+    receive() external payable {
+        received += msg.value;
     }
 }


### PR DESCRIPTION
## summary

this switches `VerifiableFactory` to a clone-backed verifiable proxy model.

each user proxy is now a tiny delegate stub with:
- shared proxy logic address
- 32-byte salt trailer for self-discovery

the shared `UUPSProxyLogic` keeps the existing behavior:
- initialization
- `getVerifiableProxyData()`
- `verifiableProxyFactory()`
- proxy-enforced `canUpgradeFrom(previousImplementation)`
- implementation-slot safety check after normal delegated calls

## gas impact

vs `main`:

| case | main | this branch | delta |
|---|---:|---:|---:|
| deploy proxy, empty init | 315,454 | 92,596 | -222,858 |
| deploy proxy, with initializer | 355,935 | 141,659 | -214,276 |

tradeoff vs the self-contained yul proxy:

| case | yul proxy | clone-backed | delta |
|---|---:|---:|---:|
| deploy empty | 203,369 | 92,596 | -110,773 |
| deploy with initializer | 252,407 | 141,659 | -110,748 |
| write call | 43,380 | 46,007 | +2,627 |
| read call | 14,987 | 17,649 | +2,662 |
| verify | 16,025 | 18,885 | +2,860 |