### PR TITLE
fix: upgrade guard + improve verifyContract interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The caller is part of `outerSalt`, so two callers can use the same user salt wit
 - the proxy address matches this factory's `CREATE2` derivation for the returned salt
 
 If verification succeeds, it returns the proxy's current implementation address. If verification fails, it reverts with `VerificationFailed(proxy)`.
-That proves the address was deployed by this factory and tells the caller which implementation it currently points at. It does not prove the implementation is safe, audited, storage-compatible with old versions, or still on its original implementation.
+That proves the address was deployed by this factory and tells the caller which implementation it currently points at. It does not prove the implementation is safe, audited, storage-compatible with old versions, or still on its original implementation. You need to trust the implementation entirely, including its upgrade authorization hook.
 
 ## Upgrading
 

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ The caller is part of `outerSalt`, so two callers can use the same user salt wit
 
 ## Verifying
 
-`verifyContract(proxy, expectedImplementation)` checks that:
+`verifyContract(proxy)` checks that:
 
 - `proxy` has code
 - `proxy` returns verifiable proxy data
-- the current implementation is `expectedImplementation`
 - the proxy address matches this factory's `CREATE2` derivation for the returned salt
 
-That proves the address was deployed by this factory and currently points at the expected implementation. It does not prove the implementation is safe, audited, storage-compatible with old versions, or still on its original implementation. After an upgrade, verify against the new current implementation.
+If verification succeeds, it returns the proxy's current implementation address. If verification fails, it reverts with `VerificationFailed(proxy)`.
+That proves the address was deployed by this factory and tells the caller which implementation it currently points at. It does not prove the implementation is safe, audited, storage-compatible with old versions, or still on its original implementation.
 
 ## Upgrading
 

--- a/src/IVerifiableFactory.sol
+++ b/src/IVerifiableFactory.sol
@@ -2,9 +2,11 @@
 pragma solidity ^0.8.20;
 
 interface IVerifiableFactory {
+    error VerificationFailed(address proxy);
+
     event ProxyDeployed(address indexed sender, address indexed proxyAddress, uint256 salt, address implementation);
 
     function deployProxy(address implementation, uint256 salt, bytes memory data) external returns (address);
 
-    function verifyContract(address proxy, address expectedImplementation) external view returns (bool);
+    function verifyContract(address proxy) external view returns (address implementation);
 }

--- a/src/UUPSProxyLogic.sol
+++ b/src/UUPSProxyLogic.sol
@@ -89,7 +89,7 @@ contract UUPSProxyLogic is IUUPSProxy {
             revert InvalidUpgradeTarget(implementation, newImplementation);
         }
 
-        _delegate(implementation, false);
+        _delegateUpgrade(implementation, newImplementation);
     }
 
     function _implementation() internal view returns (address impl) {
@@ -120,6 +120,26 @@ contract UUPSProxyLogic is IUUPSProxy {
             default {
                 return(0, returndatasize())
             }
+        }
+    }
+
+    function _delegateUpgrade(address implementation, address expectedImplementation) internal {
+        assembly {
+            calldatacopy(0, 0, calldatasize())
+
+            let result := delegatecall(gas(), implementation, 0, calldatasize(), 0, 0)
+            if iszero(result) {
+                returndatacopy(0, 0, returndatasize())
+                revert(0, returndatasize())
+            }
+
+            if iszero(eq(expectedImplementation, sload(_IMPLEMENTATION_SLOT))) {
+                mstore(0, _UPGRADE_NOT_ALLOWED_IN_CONTEXT_ERROR_SELECTOR)
+                revert(0x1c, 0x04)
+            }
+
+            returndatacopy(0, 0, returndatasize())
+            return(0, returndatasize())
         }
     }
 

--- a/src/VerifiableFactory.sol
+++ b/src/VerifiableFactory.sol
@@ -46,23 +46,22 @@ contract VerifiableFactory is IVerifiableFactory {
     }
 
     /**
-     * @dev Initiates verification of a proxy contract.
+     * @dev Verifies a proxy contract and returns its current implementation.
      *
      * This function attempts to validate a proxy contract by retrieving its salt
      * and reconstructing the address to ensure it was correctly deployed by the
      * current factory.
      *
      * @param proxy The address of the proxy contract being verified.
-     * @return A boolean indicating whether the verification succeeded.
+     * @return implementation The proxy's current implementation.
      */
-    function verifyContract(address proxy, address expectedImplementation) public view returns (bool) {
-        if (!isContract(proxy)) return false;
+    function verifyContract(address proxy) public view returns (address implementation) {
+        if (!isContract(proxy)) revert VerificationFailed(proxy);
 
         try IUUPSProxy(proxy).getVerifiableProxyData() returns (bytes32 salt, address actualImplementation) {
-            if (actualImplementation != expectedImplementation) return false;
-            return _verifyContract(proxy, salt);
+            if (_verifyContract(proxy, salt)) return actualImplementation;
         } catch {}
-        return false;
+        revert VerificationFailed(proxy);
     }
 
     function _verifyContract(address proxy, bytes32 salt) private view returns (bool) {

--- a/test/VerifiableFactory.t.sol
+++ b/test/VerifiableFactory.t.sol
@@ -5,10 +5,12 @@ import {Test} from "forge-std/Test.sol";
 import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 import {OwnableUpgradeable, Initializable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {ERC1967Utils} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
+import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
 
 import {CloneProxyBytecode} from "../src/CloneProxyBytecode.sol";
 import {VerifiableFactory} from "../src/VerifiableFactory.sol";
 import {IVerifiableFactory} from "../src/IVerifiableFactory.sol";
+import {IProxyAuthorization} from "../src/IProxyAuthorization.sol";
 import {IUUPSProxy} from "../src/IUUPSProxy.sol";
 import {MockRegistry} from "../src/mock/MockRegistry.sol";
 import {MockRegistryV2} from "../src/mock/MockRegistryV2.sol";
@@ -174,27 +176,57 @@ contract VerifiableFactoryTest is Test {
 
         vm.prank(owner);
         // verify the contract
-        bool isVerified = factory.verifyContract(proxyAddress, address(implementation));
-        assertTrue(isVerified, "Contract verification failed");
+        address verifiedImplementation = factory.verifyContract(proxyAddress);
+        assertEq(verifiedImplementation, address(implementation), "Wrong verified implementation");
 
         vm.prank(owner);
         // try to verify non-existent contract
         address randomAddress = makeAddr("random");
-        bool shouldBeFalse = factory.verifyContract(randomAddress, address(implementation));
-        assertFalse(shouldBeFalse, "Non-existent contract should not verify");
+        vm.expectRevert(abi.encodeWithSelector(IVerifiableFactory.VerificationFailed.selector, randomAddress));
+        factory.verifyContract(randomAddress);
     }
 
-    function test_VerifyContract_WrongImplementation() public {
+    function test_VerifyContract_ReturnsCurrentImplementationAfterUpgrade() public {
         uint256 salt = 1;
+        bytes memory initData = abi.encodeWithSelector(MockRegistry.initialize.selector, owner);
 
         // deploy proxy
         vm.prank(owner);
-        address proxyAddress = factory.deployProxy(address(implementation), salt, emptyData);
+        address proxyAddress = factory.deployProxy(address(implementation), salt, initData);
 
         vm.prank(owner);
-        // verify the contract
-        bool isVerified = factory.verifyContract(proxyAddress, address(implementationV2));
-        assertFalse(isVerified, "Contract verification should fail");
+        MockRegistry(proxyAddress).upgradeToAndCall(address(implementationV2), "");
+
+        address verifiedImplementation = factory.verifyContract(proxyAddress);
+        assertEq(verifiedImplementation, address(implementationV2), "Wrong upgraded implementation");
+    }
+
+    function test_VerifyContract_RejectsTrustedImplementationAfterBypassedUpgrade() public {
+        uint256 salt = 1;
+        UpgradeAuthorizationBypass untrustedImplementation = new UpgradeAuthorizationBypass(address(implementationV2));
+        PermissiveUpgradeTarget claimedUpgradeTarget = new PermissiveUpgradeTarget();
+
+        assertFalse(
+            implementationV2.canUpgradeFrom(address(untrustedImplementation)),
+            "Trusted implementation should reject the untrusted predecessor"
+        );
+
+        vm.prank(owner);
+        address proxyAddress = factory.deployProxy(address(untrustedImplementation), salt, emptyData);
+        assertEq(
+            factory.verifyContract(proxyAddress),
+            address(untrustedImplementation),
+            "Proxy should start on the untrusted implementation"
+        );
+
+        vm.expectRevert(abi.encodeWithSelector(IUUPSProxy.UpgradeNotAllowedInContext.selector));
+        IUpgradeToAndCall(proxyAddress).upgradeToAndCall(address(claimedUpgradeTarget), "");
+
+        assertEq(
+            factory.verifyContract(proxyAddress),
+            address(untrustedImplementation),
+            "Proxy should stay on the untrusted implementation after rejected bypass"
+        );
     }
 
     function test_ProxyInitialization() public {
@@ -342,8 +374,8 @@ contract VerifiableFactoryTest is Test {
         address proxy = factory.deployProxy(address(impl), salt, initData);
 
         // verification checks
-        bool verified = factory.verifyContract(proxy, address(impl));
-        assertTrue(verified, "Fuzz verification failed");
+        address verifiedImplementation = factory.verifyContract(proxy);
+        assertEq(verifiedImplementation, address(impl), "Fuzz verification failed");
 
         // additional safety assertions
         assertEq(IUUPSProxy(proxy).verifiableProxyFactory(), address(factory), "Factory relationship broken");
@@ -373,5 +405,31 @@ contract PayableReceiver {
 
     receive() external payable {
         received += msg.value;
+    }
+}
+
+contract PermissiveUpgradeTarget is IProxyAuthorization {
+    function canUpgradeFrom(address) external pure returns (bool) {
+        return true;
+    }
+}
+
+interface IUpgradeToAndCall {
+    function upgradeToAndCall(address newImplementation, bytes calldata data) external payable;
+}
+
+contract UpgradeAuthorizationBypass is IProxyAuthorization {
+    address private immutable forcedImplementation;
+
+    constructor(address forcedImplementation_) {
+        forcedImplementation = forcedImplementation_;
+    }
+
+    function canUpgradeFrom(address) external pure returns (bool) {
+        return true;
+    }
+
+    function upgradeToAndCall(address, bytes calldata) external payable {
+        StorageSlot.getAddressSlot(ERC1967Utils.IMPLEMENTATION_SLOT).value = forcedImplementation;
     }
 }


### PR DESCRIPTION
this tightens the trusted upgrade path and simplifies the `verifyContract` interface.

the upgrade guard now requires an `upgradeToAndCall(newImplementation, data)` call to leave the proxy's ERC-1967 implementation slot set to `newImplementation`. this prevents a current implementation from passing the pre-check for one target, then writing a different implementation into the slot during the delegated upgrade.

`verifyContract` now returns the current implementation address discovered from the proxy instead of requiring callers to provide an expected implementation. if verification fails, it reverts with `VerificationFailed(proxy)`.

changes:
- UUPSProxyLogic:
  - added a dedicated upgrade delegate path which checks the implementation slot after the delegated upgrade
  - reverts with `UpgradeNotAllowedInContext` if the slot does not match the requested upgrade target
- VerifiableFactory:
  - changed `verifyContract(proxy, expectedImplementation) returns (bool)` to `verifyContract(proxy) returns (address implementation)`
  - verification failure now reverts instead of returning `address(0)`
- docs:
  - updated verifying docs for the new api
  - clarified that callers need to trust the implementation entirely, including its upgrade authorization hook
- tests:
  - updated verifyContract coverage for the new return value/revert behavior
  - added regression coverage for a bypassed upgrade authorization attempt